### PR TITLE
Fix memory leak in leveldb patch - Stop memory crashes

### DIFF
--- a/patches/leveldb-1.22.patch
+++ b/patches/leveldb-1.22.patch
@@ -562,6 +562,9 @@ diff -ruN leveldb/table/format.cc leveldb-mcpe/table/format.cc
 +    }
 +    case kZlibRawCompression: {
 +      std::string output;
++      if (options.decompress_allocator) {
++				output = options.decompress_allocator->get();
++      }
 +      if (!ZlibRaw_Uncompress(data, n, output)) {
 +        delete[] buf;
 +        return Status::Corruption("corrupted compressed block contents");


### PR DESCRIPTION
The leveldb patch leaks memory due to some bad moves on uncompressed world data.

It causes ballooning of memory due to pointless copies of the chunk data.

Using the allocator for string in patch fixes this.

Sits around 600Mb constant for me with a large map and produces output fine, before it would grow to consume all RAM before crashing.