### PR TITLE
Help cleanup and other fixes

### DIFF
--- a/patches/leveldb-1.22.patch
+++ b/patches/leveldb-1.22.patch
@@ -536,7 +536,7 @@ diff -ruN leveldb/table/format.cc leveldb-mcpe/table/format.cc
  void BlockHandle::EncodeTo(std::string* dst) const {
    // Sanity check that all fields have been set
    assert(offset_ != ~static_cast<uint64_t>(0));
-@@ -130,6 +158,45 @@
+@@ -130,6 +158,48 @@
        result->cachable = true;
        break;
      }

--- a/src/args.cc
+++ b/src/args.cc
@@ -1,11 +1,10 @@
 #include "args.h"
+#include "global.h"
 #include <cstdio>
 
 
 namespace {
-
-    const char * const usage = R"(Usage:
-
+    const char* const usage = R"(Usage:
     bedrock-viz [required parameters] [options]
 
 Required Parameters:
@@ -20,15 +19,35 @@ Options:
     --auto-tile              Automatically tile the images if they are very large
     --tiles[=tilew,tileh]    Create tiles in subdirectory tiles/ (useful for LARGE worlds)
 
+    --slices[=did]           Create slices (one image for each layer)
+    --movie[=did]            Create movie of layers
+    --movie-dim x,y,w,h      Integers describing the bounds of the movie (UL X, UL Y, WIDTH, HEIGHT)
+
+    --xml fn                 XML file containing data definitions
+    --cfg fn                 CFG file containing parsing configuration
+
+    --detail                 Log extensive details about the world to the log file
+    --verbose                verbose output
+    --quiet                  supress normal output, continue to output warning and error messages
+    --help                   show basic help info
+    --help-extended          show extended help info
+    --help-experimental      show experimental help info
+)";
+
+
+    const char * const usage_extended = R"(
+Extended Options:
     --hide-top=did,bid       Hide a block from top block (did=dimension id, bid=block id)
     --force-top=did,bid      Force a block to top block (did=dimension id, bid=block id)
     --geojson-block=did,bid  Add block to GeoJSON file for use in web app (did=dimension id, bid=block id)
 
-    --check-spawn did,x,z,dist  Add spawnable blocks to the geojson file (did=dimension id; checks a circle of radius 'dist' centered on x,z)
-    --schematic-get did,x1,y1,z1,x2,y2,z2,fnpart   Create a schematic file (fnpart) from (x1,y1,z1) to (x2,y2,z2) in dimension (did)
-        (note: [=did] is optional dimension-id - if not specified, do all dimensions; 0=Overworld; 1=Nether)\n"
-    --grid[=did]             Display chunk grid on top of images
+    --check-spawn[able] did,x,z,dist
+                             Add spawnable blocks to the geojson file (did=dimension id; checks a circle of radius 'dist' centered on x,z)
+    --schematic[-get] did,x1,y1,z1,x2,y2,z2,fnpart
+                             Create a schematic file (fnpart) from (x1,y1,z1) to (x2,y2,z2) in dimension (did)
 
+    (note: [=did] is optional dimension-id - if not specified, do all dimensions; 0=Overworld; 1=Nether)\n"
+    --grid[=did]             Display chunk grid on top of images
     --all-image[=did]        Create all image types
     --biome[=did]            Create a biome map image
     --grass[=did]            Create a grass color map image
@@ -40,24 +59,27 @@ Options:
     --skylight[=did]         Create a sky light map image
     --slime-chunk[=did]      Create a slime chunk map image
 
-    --slices[=did]           Create slices (one image for each layer)
-    --movie[=did]            Create movie of layers
-    --movie-dim x,y,w,h      Integers describing the bounds of the movie (UL X, UL Y, WIDTH, HEIGHT)
-
-    --xml fn                 XML file containing data definitions
-
     --no-force-geojson       Don't load geojson in html because we are going to use a web server (or Firefox)
+)";
 
-    --detail                 Log extensive details about the world to the log file
-    --verbose                verbose output
-    --quiet                  supress normal output, continue to output warning and error messages
-    --help                   show this info
+
+    const char* const usage_experimental = R"(
+Experimental Options:
+    --shortrun               Debug testing parameter - process only first 1000 records
+    --leveldb-filter=i       Bloom filter supposed to improve disk performance (default: 10)
+    --leveldb-block-size=i   The block size of leveldb (default: 4096)
 )";
 }
 
 namespace mcpe_viz{
-    void print_usage()
+    void print_usage(char helpFlags)
     {
         printf("%s", usage);
+    
+        if (helpFlags & HelpFlags::Extended)
+            printf("%s", usage_extended);
+
+        if (helpFlags & HelpFlags::Experimental)
+            printf("%s", usage_experimental);
     }
 }

--- a/src/args.h
+++ b/src/args.h
@@ -1,6 +1,5 @@
 #pragma once
 
 namespace mcpe_viz {
-
-    void print_usage();
+    void print_usage(char helpFlags);
 }

--- a/src/asset.cc
+++ b/src/asset.cc
@@ -25,8 +25,9 @@ namespace mcpe_viz {
         return use_argv_0 ? argv_0 : prefix;
     }
 
-    path xml_path() {
-        return get_prefix() / "data" / "mcpe_viz.xml";
+    path data_path(const std::string& filename)
+    {
+        return get_prefix() / "data" / filename;
     }
 
     path static_path(const std::string& filename)

--- a/src/asset.h
+++ b/src/asset.h
@@ -5,7 +5,7 @@
 #include <string>
 
 namespace mcpe_viz {
-    std::filesystem::path xml_path();
+    std::filesystem::path data_path(const std::string& filename);
 
     std::filesystem::path static_path(const std::string& filename);
 

--- a/src/control.h
+++ b/src/control.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 
 #include "define.h"
+#include "global.h"
 
 namespace mcpe_viz {
 
@@ -54,6 +55,7 @@ namespace mcpe_viz {
         bool shortRunFlag;
         bool verboseFlag;
         bool quietFlag;
+        char helpFlags;
         int32_t movieX, movieY, movieW, movieH;
 
         int32_t heightMode;
@@ -100,6 +102,7 @@ namespace mcpe_viz {
             shortRunFlag = false;
             verboseFlag = false;
             quietFlag = false;
+            helpFlags = HelpFlags::Basic;
             movieX = movieY = movieW = movieH = 0;
 
             leveldbFilter = 10;

--- a/src/global.h
+++ b/src/global.h
@@ -4,6 +4,12 @@
 #include <string>
 
 namespace mcpe_viz {
+    enum HelpFlags : char {
+        Basic        = 0x00,
+        Extended     = 0x01,
+        Experimental = 0x02
+    };
+
 
     //todozooz - MAX_BLOCK_ID MAX_ITEM_ID etc
     // todo ugly globals

--- a/src/main.cc
+++ b/src/main.cc
@@ -670,16 +670,19 @@ namespace mcpe_viz {
             // --tiles[=tilew,tileh]
             case '[': {
                 control.doTiles = true;
-                int32_t tw, th;
+                if (optarg)
+                {
+                    int32_t tw, th;
 
-                if (sscanf(optarg, "%d,%d", &tw, &th) == 2) {
-                    control.tileWidth = tw;
-                    control.tileHeight = th;
-                    log::info("Overriding tile dimensions: {} x {}", tw, th);
-                }
-                else {
-                    log::error("Failed to parse --tiles ({})", optarg ? optarg : "null");
-                    errct++;
+                    if (sscanf(optarg, "%d,%d", &tw, &th) == 2) {
+                        control.tileWidth = tw;
+                        control.tileHeight = th;
+                        log::info("Overriding tile dimensions: {} x {}", tw, th);
+                    }
+                    else {
+                        log::error("Failed to parse --tiles ({})", optarg ? optarg : "null");
+                        errct++;
+                    }
                 }
                 break;
             }

--- a/src/main.cc
+++ b/src/main.cc
@@ -241,7 +241,7 @@ namespace mcpe_viz {
             log::error("Failed to open file ({}) error={} ({})", fn, strerror(errno), errno);
             return 1;
         }
-        log::info("Reading config from {}", fn);
+        log::info("Loading config from ({})", fn);
 
         char buf[1025], * p;
         while (!feof(fp)) {
@@ -345,30 +345,44 @@ namespace mcpe_viz {
         // parse cfg files in this order:
         // -- option specified on command-line
         // -- home dir
+        // -- userprofile dir
         // -- local dir
+        std::string configFile;
 
         // as specified on cmdline
-        if (!control.fnCfg.empty()) {
-            if (doParseConfigFile(control.fnCfg) == 0) {
-                return 0;
-            }
+        if (!control.fnCfg.empty())
+        {
+            if (doParseConfigFile(control.fnCfg) == 0)
+                configFile = control.fnCfg;
         }
 
-        // default config file
-        // todo - how to support on win32? %HOMEPATH%?
-        if (getenv("HOME")) {
+        // default config file from home
+        if (configFile.empty() && getenv("HOME")) {
             std::string fnHome = getenv("HOME");
             fnHome += "/.mcpe_viz.cfg";
-            if (doParseConfigFile(fnHome) == 0) {
-                return 0;
-            }
+            if (doParseConfigFile(fnHome) == 0)
+                configFile = fnHome;
         }
 
-        // local dir
-        if (doParseConfigFile(std::string("mcpe_viz.cfg")) == 0) {
-            return 0;
+        // default config file from profile directory
+        if (configFile.empty() && getenv("USERPROFILE")) {
+            std::string fnHome = getenv("USERPROFILE");
+            fnHome += "/.mcpe_viz.cfg";
+            if (doParseConfigFile(fnHome) == 0)
+                configFile = fnHome;
         }
-        return -1;
+
+        // local data dir
+        if (configFile.empty() && doParseConfigFile(data_path("mcpe_viz.cfg").generic_string()) == 0)
+            configFile = data_path("mcpe_viz.cfg").generic_string();
+
+        if (configFile.empty())
+        {
+            log::error("Could not find a valid config file to load");
+            return -1;
+        }
+        else
+            return 0;
     }
 
     int32_t parseDimIdOptArg(const char* arg) {
@@ -399,6 +413,7 @@ namespace mcpe_viz {
                 
 
                 {"xml",                required_argument, nullptr, 'X'},
+                {"cfg",                required_argument, nullptr, 'c'},
 
                 {"detail",             no_argument,       nullptr, '@'},
 
@@ -440,14 +455,14 @@ namespace mcpe_viz {
 
                 {"shortrun",           no_argument,       nullptr, '$'}, // this is just for testing
 
-                {"flush",              no_argument,       nullptr, 'f'},
-
                 {"leveldb-filter",     required_argument, nullptr, '<'},
                 {"leveldb-block-size", required_argument, nullptr, '>'},
 
                 {"verbose",            no_argument,       nullptr, 'v'},
                 {"quiet",              no_argument,       nullptr, 'q'},
                 {"help",               no_argument,       nullptr, 'h'},
+                {"help-extended",      no_argument,       nullptr, 'u'},
+                {"help-experimental",  no_argument,       nullptr, 'i'},
                 {nullptr,              no_argument,       nullptr, 0}
         };
 
@@ -459,31 +474,48 @@ namespace mcpe_viz {
 
         while ((optc = getopt_long_only(argc, argv, "", longoptlist, &option_index)) != -1) {
             switch (optc) {
-            case 'o':
+            // --outdir dir
+            case 'o': {
                 control.outputDir = optarg;
                 break;
-            case 'X':
+            }
+            // --xml fn
+            case 'X': {
                 control.fnXml = optarg;
                 break;
-            case 'D':
+            }
+            // --cfg fn
+            case 'c': {
+                control.fnCfg = optarg;
+                break;
+            }
+            // --db dir
+            case 'D': {
                 control.dirLeveldb = optarg;
                 break;
-            case '@':
+            }
+            // --detail
+            case '@': {
                 control.doDetailParseFlag = true;
                 break;
-
-            case '<':
+            }
+            // --leveldb-filter i
+            case '<': {
                 control.leveldbFilter = atoi(optarg);
                 if (control.leveldbFilter < 0) {
                     control.leveldbFilter = 0;
                 }
                 break;
-            case '>':
+            }
+            // --leveldb-block-size i
+            case '>': {
                 control.leveldbBlockSize = atoi(optarg);
                 if (control.leveldbBlockSize < 0) {
                     control.leveldbBlockSize = 4096;
                 }
                 break;
+            }
+            // --hide-top=did,bid
             case 'H': {
                 bool pass = false;
                 int32_t dimId, blockId;
@@ -508,9 +540,9 @@ namespace mcpe_viz {
                     log::error("Failed to parse --hide-top {}", optarg);
                     errct++;
                 }
+                break;
             }
-                    break;
-
+            // --force-top=did,bid
             case 'F': {
                 bool pass = false;
                 int32_t dimId, blockId;
@@ -535,9 +567,9 @@ namespace mcpe_viz {
                     log::error("Failed to parse --force-top {}", optarg);
                     errct++;
                 }
+                break;
             }
-                    break;
-
+            // --geojson-block=did,bid
             case '+': {
                 bool pass = false;
                 int32_t dimId, blockId;
@@ -562,9 +594,10 @@ namespace mcpe_viz {
                     log::error("Failed to parse --geojson-block {}", optarg);
                     errct++;
                 }
+                break;
             }
-                    break;
-
+            // --check-spawn did,x,z,dist
+            // --check-spawnable did,x,z,dist
             case 'C': {
                 log::warn("--spawnable is no longer supported because the new chunk format (circa beta 1.2.x) no longer stores block light info");
                 errct++;
@@ -591,10 +624,10 @@ namespace mcpe_viz {
                     log::error("Failed to parse --check-spawn {}", optarg);
                     errct++;
                 }
+                break;
             }
-                    break;
-
-
+            // --schematic did,x1,y1,z1,x2,y2,z2,fnpart
+            // --schematic-get did,x1,y1,z1,x2,y2,z2,fnpart
             case 'Z': {
                 bool pass = false;
                 int32_t dimId = 0, x1 = 0, y1 = 0, z1 = 0, x2 = 0, y2 = 0, z2 = 0;
@@ -622,37 +655,41 @@ namespace mcpe_viz {
                     log::error("Failed to parse --schematic {}", optarg);
                     errct++;
                 }
+                break;
             }
-                    break;
-
-
-            case 'G':
+            // --grid[=did]
+            case 'G': {
                 control.doGrid = parseDimIdOptArg(optarg);
                 break;
-
-            case ')':
+            }
+            // --html
+            case ')': {
                 control.doHtml = true;
                 break;
-
-            case '[':
+            }
+            // --tiles[=tilew,tileh]
+            case '[': {
                 control.doTiles = true;
-                {
-                    int32_t tw, th;
-                    if (optarg) {
-                        if (sscanf(optarg, "%d,%d", &tw, &th) == 2) {
-                            control.tileWidth = tw;
-                            control.tileHeight = th;
-                            log::info("Overriding tile dimensions: %d x %d", tw, th);
-                        }
-                    }
+                int32_t tw, th;
+
+                if (sscanf(optarg, "%d,%d", &tw, &th) == 2) {
+                    control.tileWidth = tw;
+                    control.tileHeight = th;
+                    log::info("Overriding tile dimensions: {} x {}", tw, th);
+                }
+                else {
+                    log::error("Failed to parse --tiles ({})", optarg ? optarg : "null");
+                    errct++;
                 }
                 break;
-            case ']':
+            }
+            // --auto-tile
+            case ']': {
                 control.autoTileFlag = true;
                 break;
-
-            case '=':
-                // html most
+            }
+            // --html-most
+            case '=': {
                 control.doHtml = true;
                 control.doImageBiome =
                     control.doImageGrass =
@@ -665,9 +702,9 @@ namespace mcpe_viz {
                     control.doImageSlimeChunks =
                     kDoOutputAll;
                 break;
-
-            case '_':
-                // html all
+            }
+            // --html-all
+            case '_': {
                 control.doHtml = true;
                 control.doImageBiome =
                     control.doImageGrass =
@@ -681,40 +718,59 @@ namespace mcpe_viz {
                     kDoOutputAll;
                 control.doSlices = kDoOutputAll;
                 break;
-
-            case ':':
+            }
+            // --no-force-geojson
+            case ':': {
                 control.noForceGeoJSONFlag = true;
                 break;
-
-            case 'B':
+            }
+            // --biome[=did]
+            case 'B': {
                 control.doImageBiome = parseDimIdOptArg(optarg);
                 break;
-            case 'g':
+            }
+            // --grass[=did]
+            case 'g': {
                 control.doImageGrass = parseDimIdOptArg(optarg);
                 break;
-            case 'd':
+            }
+            // --height-col[=did]
+            case 'd': {
                 control.doImageHeightCol = parseDimIdOptArg(optarg);
                 break;
-            case '#':
+            }
+            // --height-col-gs[=did]
+            case '#': {
                 control.doImageHeightColGrayscale = parseDimIdOptArg(optarg);
                 break;
-            case 'a':
+            }
+            // --height-col-alpha[=did]
+            case 'a': {
                 control.doImageHeightColAlpha = parseDimIdOptArg(optarg);
                 break;
-            case 'S':
+            }
+            // --shaded-relief[=did]
+            case 'S': {
                 control.doImageShadedRelief = parseDimIdOptArg(optarg);
                 break;
-            case 'b':
+            }
+            // --blocklight[=did]
+            case 'b': {
                 control.doImageLightBlock = parseDimIdOptArg(optarg);
                 break;
-            case 's':
+            }
+            // --skylight[=did]
+            case 's': {
                 control.doImageLightSky = parseDimIdOptArg(optarg);
                 break;
-            case '%':
+            }
+            // --slime-chunk[=did]
+            case '%': {
                 control.doImageSlimeChunks = parseDimIdOptArg(optarg);
                 break;
-
-            case 'A':
+            }
+            // --all-image[=did]
+            case 'A': {
                 control.doImageBiome =
                     control.doImageGrass =
                     control.doImageHeightCol =
@@ -726,14 +782,19 @@ namespace mcpe_viz {
                     control.doImageSlimeChunks =
                     parseDimIdOptArg(optarg);
                 break;
-
-            case '(':
+            }
+            // --slices[=did]
+            case '(': {
                 control.doSlices = parseDimIdOptArg(optarg);
                 break;
-            case 'M':
+            }
+            // --movie[=did]
+            case 'M': {
                 control.doMovie = parseDimIdOptArg(optarg);
                 break;
-            case '*':
+            }
+            // --movie-dim x,y,w,h
+            case '*': {
                 // movie dimensions
                 if (sscanf(optarg, "%d,%d,%d,%d", &control.movieX, &control.movieY, &control.movieW,
                     &control.movieH) == 4) {
@@ -744,22 +805,42 @@ namespace mcpe_viz {
                     errct++;
                 }
                 break;
-
-            case '$':
+            }
+            // --shortrun
+            case '$': {
                 control.shortRunFlag = true;
                 break;
-            case 'v':
+            }
+            // --verbose
+            case 'v': {
                 control.verboseFlag = true;
                 break;
-            case 'q':
+            }
+            // --quiet
+            case 'q': {
                 control.quietFlag = true;
                 break;
-            default:
+            }
+            // --help
+            case 'h': {
+                control.helpFlags = HelpFlags::Basic;
+                return -1;
+            }
+            // --help-extended
+            case 'u': {
+                control.helpFlags = HelpFlags::Basic | HelpFlags::Extended;
+                return -1;
+            }
+            // --help-experimental
+            case 'i': {
+                control.helpFlags = HelpFlags::Basic | HelpFlags::Extended | HelpFlags::Experimental;
+                return -1;
+            }
+            // unknown option
+            default: {
                 log::error("Unrecognized option: '{}'", optc);
                 return -1;
-
-            case 'h':
-                return -1;
+            }
             }
         }
 
@@ -804,7 +885,7 @@ int main(int argc, char** argv)
     world = std::make_unique<MinecraftWorld_LevelDB>();
 
     if (parse_args(argc, argv) != 0) {
-        mcpe_viz::print_usage();
+        mcpe_viz::print_usage(control.helpFlags);
         return -1;
     }
     if (control.doHtml) {
@@ -818,7 +899,7 @@ int main(int argc, char** argv)
     {
         int ret = 0;
         if (control.fnXml.empty()) {
-            ret = load_xml(xml_path().generic_string());
+            ret = load_xml(data_path("mcpe_viz.xml").generic_string());
         }
         else {
             ret = load_xml(control.fnXml);

--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -220,7 +220,7 @@ namespace mcpe_viz
             catch (std::exception & e) {
                 // check for eof which means all is well
                 if (!pis.eof()) {
-                    fprintf(stderr, "NBT exception: (%s) (eof=%s) (is=%s) (tc=%d) (pos=%d) (buflen=%d) (parseNbt)\n"
+                    log::error("NBT exception: ({}) (eof={}) (is={}) (tc={}) (pos={}) (buflen={}) (parseNbt)"
                         , e.what()
                         , pis.eof() ? "true" : "false"
                         , (pis) ? "true" : "false"
@@ -269,7 +269,7 @@ namespace mcpe_viz
             catch (std::exception & e) {
                 // check for eof which means all is well
                 if (!pis.eof()) {
-                    fprintf(stderr, "NBT exception: (%s) (eof=%s) (is=%s) (tc=%d) (pos=%d) (buflen=%d) (parseNbtQuiet)\n"
+                    log::error("NBT exception: ({}) (eof={}) (is={}) (tc={}) (pos={}) (buflen={}) (parseNbtQuiet)"
                         , e.what()
                         , pis.eof() ? "true" : "false"
                         , (pis) ? "true" : "false"
@@ -985,7 +985,7 @@ namespace mcpe_viz
                     //List = 9,
                     //Compound = 10,
                     //Int_Array = 11,
-                    fprintf(stderr, "WARNING: Unable to capture entity other prop key=%s\n", key.c_str());
+                    log::warn("Unable to capture entity other prop key={}", key.c_str());
                     break;
                 }
             }
@@ -1226,7 +1226,12 @@ namespace mcpe_viz
                 worldPointToGeoJSONPoint(actualDimensionId, pos.x, pos.z, playerPositionImageX, playerPositionImageY);
                 playerPositionDimensionId = actualDimensionId;
 
-                fprintf(stderr, "Player Position: Dimension=%d Pos=%s Rotation=(%lf, %lf)\n", actualDimensionId, pos.toStringWithImageCoords(actualDimensionId).c_str(), rotation.x, rotation.y);
+                log::info("Player Position: Dimension={} Pos={} Rotation=({}, {})"
+                    , actualDimensionId
+                    , pos.toStringWithImageCoords(actualDimensionId).c_str()
+                    , rotation.x
+                    , rotation.y
+                );
             }
 
             if (playerLocalFlag || playerRemoteFlag) {
@@ -1618,7 +1623,7 @@ namespace mcpe_viz
                 // all is good
             }
             else {
-                fprintf(stderr, "ERROR: parseNbt_entity() called with invalid tagList (loop=%d)\n", (int)i);
+                log::error("ERROR: parseNbt_entity() called with invalid tagList (loop={})", (int)i);
                 return -1;
             }
 
@@ -2006,7 +2011,7 @@ namespace mcpe_viz
                 // all is good
             }
             else {
-                fprintf(stderr, "ERROR: parseNbt_tileEntity() called with invalid tagList (loop=%d)\n", (int)i);
+                log::error("parseNbt_tileEntity() called with invalid tagList (loop={})", (int)i);
                 return -1;
             }
 

--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -311,7 +311,7 @@ namespace mcpe_viz
 
                 for (const auto& iter : dimDataList[dimId]->blockToGeoJSONList) {
                     blockId = iter;
-                    log::info("  'genjson' block: {} - {} (dimId={} blockId={} (0x{:x}))",
+                    log::info("  'geojson' block: {} - {} (dimId={} blockId={} (0x{:x}))",
                         dimDataList[dimId]->getName(),
                               Block::queryName(blockId),
                         dimId, blockId, blockId);

--- a/src/xml/loader.cc
+++ b/src/xml/loader.cc
@@ -10,6 +10,7 @@ namespace mcpe_viz
 {
     int load_xml(const std::string& filepath)
     {
+        log::info("Loading config from ({})", filepath);
         pugi::xml_document doc;
         auto result = doc.load_file(filepath.c_str());
 


### PR DESCRIPTION
This PR covers the following issues

- resolves #23 and resolves #22 - There was a line offset that needed to be updated from @bazfp's update
- resolves #27 - All of the help code has been updated to have consistent code style and offers options for basic/common options, extended options, and experimental options.
- resolves #28 - There were multiple debug and error messages that were not getting sent through to spdlog. I think I got most of them now.
- resolves #18 - Added a function to pull from the data folder for the xml and cfg files. Also added support for loading a cfg from the homepath on windows machines.
- geojson block log message had a typo
