### PR TITLE
remove placeholder if it's not going to be used

### DIFF
--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -895,6 +895,14 @@ namespace mcpe_viz
                 "\"></script>"
             )
             );
+        } else {
+            // remove the placeholder it would have gone to
+            replaceStrings.push_back(
+                std::make_pair(
+                    std::string("%JSFILE%"),
+                    ""
+                )
+            );
         }
         copyFileWithStringReplacement(fnHtmlSrc, control.fnHtml().generic_string(), replaceStrings);
 


### PR DESCRIPTION
building with `--no-force-geojson` currently leaves `%JSFILE%` in the generated index.html, which then renders in the browser and kills an entire text line worth of height on the display.

![image](https://user-images.githubusercontent.com/522147/86894953-a603be00-c0b8-11ea-9847-f9ae3be9a2d0.png)

(note not sure this is the best solution, I just aped the code that was in the if leg to replace it with nothing and it works.)