### PR TITLE
signs may not have all 4 text lines

### DIFF
--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -872,9 +872,11 @@ function correctGeoJSONName(feature) {
         var props = feature.getProperties();
         var a = [];
         var pushTrimmedString = function(a, str) {
-            var s = str.trim();
-            if (s.length > 0 ) {
-                a.push(s);
+            if (str) {
+                var s = str.trim();
+                if (s.length > 0 ) {
+                    a.push(s);
+                }
             }
         };
         pushTrimmedString(a, props[name].Text1);


### PR DESCRIPTION
fixes #70 by detecting that `src` is `undefined` and not trying to trim it, or test it's length, or use it.