### PR TITLE
Track item variants by uname

### DIFF
--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -1453,7 +1453,7 @@
       <itemvariant extradata="39" name="Arrow of the Turtle Master (0:30)" uname="minecraft:" />
       <itemvariant extradata="40" name="Arrow of the Turtle Master (0:30)" uname="minecraft:" />
     </item>
-    <item id="0x107" name="Coal" uname="minecraft:coal"> <!-- *B -->
+    <item id="0x107" name="Coal"> <!-- *B -->
       <itemvariant extradata="0" name="Coal" uname="minecraft:coal" />
       <itemvariant extradata="1" name="Charcoal" uname="minecraft:charcoal" />
     </item>
@@ -1521,7 +1521,7 @@
     </item>
     <item id="0x143" name="Oak Sign" uname="minecraft:sign" />
     <item id="0x144" name="Oak Door" uname="minecraft:wooden_door" />
-    <item id="0x145" name="Bucket" uname="minecraft:bucket">
+    <item id="0x145" name="Bucket">
       <itemvariant extradata="0x0" name="Bucket, Empty" uname="minecraft:bucket" />
       <itemvariant extradata="0x1" name="Bucket, Milk" uname="minecraft:milk_bucket" />
       <itemvariant extradata="0x2" name="Bucket, Cod" uname="minecraft:cod_bucket" />

--- a/src/xml/load_item.cc
+++ b/src/xml/load_item.cc
@@ -45,6 +45,17 @@ namespace mcpe_viz
                         var_name, extradata);
                     return -1;
                 }
+                auto var_unames = j.attribute("uname").as_string();
+                auto var_uname_list = mysplit(var_unames, ';');
+                for (auto& var_uname : var_uname_list) {
+                    /* there are a LOT of item variants that we don't know the proper
+                     * uname for yet. They just have place holders in the xml waiting to
+                     * be filled in. Skip those placeholders so we don't get conflicts.
+                     */
+                    if (var_uname != "minecraft:") {
+                        item->addUname(var_uname);
+                    }
+                }
             }
         }
         return 0;


### PR DESCRIPTION
We have uname values in the xml for lots of item variants, but when they are in inventory they still can't be found because the variants weren't tracked by their uname, only the base item was. This seems to resolve that. I'm still looking into what other side effects it causes, but wanted to start a conversation on the proposal to change that.