### PR TITLE
unique colors for all block variants

### DIFF
--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -606,7 +606,7 @@
       <blockvariant blockdata="0xc" name="Leaves, Acacia (no + check decay)" />
       <blockvariant blockdata="0xd" name="Leaves, Dark Oak (no + check decay)" />
     </block>
-    <block id="0xA2" name="Wood (Acacia/Dark Oak)" uname="minecraft:log2" color="0x69702c"> <!-- *B -->
+    <block id="0xA2" name="Wood (Acacia/Dark Oak)" uname="minecraft:log2" color="0x697020"> <!-- *B -->
       <blockvariant blockdata="0x0" name="Wood, Acacia (Up/Down)" />
       <blockvariant blockdata="0x1" name="Wood, Dark Oak (Up/Down)" />
       <blockvariant blockdata="0x4" name="Wood, Acacia (East/West)" />
@@ -616,7 +616,7 @@
       <blockvariant blockdata="0xc" name="Wood, Acacia (Bark Only)" />
       <blockvariant blockdata="0xd" name="Wood, Dark Oak (Bark Only)" />
     </block>
-    <block id="0xA3" name="Stairs, Acacia Wood" uname="minecraft:acacia_stairs" color="0x69712c" spawnable="0"> <!-- *S -->
+    <block id="0xA3" name="Stairs, Acacia Wood" uname="minecraft:acacia_stairs" color="0x697220" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Acacia Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Acacia Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Acacia Wood, South" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -1927,7 +1927,7 @@
     <item id="0x1d9" name="Birch Sign" uname="minecraft:birch_sign" />
     <item id="0x1da" name="Jungle Sign" uname="minecraft:jungle_sign" />
     <item id="0x1db" name="Acacia Sign" uname="minecraft:acacia_sign" />
-    <item id="0x1dc" name="Dark Oak Sign" uname="minecraft:darkoak_sign" />
+    <item id="0x1dc" name="Dark Oak Sign" uname="minecraft:dark_oak_sign" />
     <item id="0x1dd" name="Sweet Berries" uname="minecraft:sweet_berries" />
     <item id="0x1F2" name="Camera" uname="minecraft:camera" /> <!-- EDU -->
     <item id="0x1F3" name="Salt" uname="minecraft:compound" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -1257,7 +1257,7 @@
     <block id="0x1BF" name="Darkoak Standing Sign" uname="minecraft:darkoak_standing_sign" color="0x69722a" />
     <block id="0x1C0" name="Darkoak Wall Sign" uname="minecraft:darkoak_wall_sign" color="0x69722d" />
     <block id="0x1c1" name="lectern" uname="minecraft:lectern" color="0x895c27" />
-    <block id="0x1c2" name="Grindstone" uname="minecraft:grindstone" color="0xe808180" />
+    <block id="0x1c2" name="Grindstone" uname="minecraft:grindstone" color="0x808180" />
     <block id="0x1c3" name="Blast Furnace" uname="minecraft:blast_furnace" color="0xe54e27" />
     <block id="0x1c4" name="Stonecutter Block" uname="minecraft:stonecutter_block" color="0x8a8080" />
     <block id="0x1c5" name="Smoker" uname="minecraft:smoker" color="0x895c28" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -508,7 +508,7 @@
     <block id="0x98" name="Block of Redstone" uname="minecraft:redstone_block" color="0xcd5c5c" opaque="0" />
     <block id="0x99" name="Nether Quartz Ore" uname="minecraft:quartz_ore" color="0xd6cdcd" />
     <block id="0x9A" name="Hopper" uname="minecraft:hopper" color="0xa5a5a5" opaque="0" spawnable="0" /> <!-- *S *E 0.14 -->
-    <block id="0x9B" name="Block of Quartz" uname="minecraft:quartz_block" color="0xfffff1"> <!-- *B -->
+    <block id="0x9B" name="Block of Quartz" uname="minecraft:quartz_block" color="0xfffef1"> <!-- *B -->
       <blockvariant blockdata="0x0" name="Block of Quartz" />
       <blockvariant blockdata="0x1" name="Chiseled Quartz Block (Vertical)" />
       <blockvariant blockdata="0x2" name="Pillar Quartz Block (Vertical)" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -531,7 +531,7 @@
       <blockvariant blockdata="0x7" name="Stairs, Quartz, North (Upside-down)" spawnable="1" />
     </block>
     <!-- note: on MCPC 0x9d is "Activator Rail" *S -->
-    <block id="0x9D" name="Wooden Double Slab" uname="minecraft:double_wooden_slab" color="0x696f2c">
+    <block id="0x9D" name="Wooden Double Slab" uname="minecraft:double_wooden_slab" color="0x686f2c">
       <blockvariant blockdata="0x0" name="Double Slab, Oak Wood" />
       <blockvariant blockdata="0x1" name="Double Slab, Spruce Wood" />
       <blockvariant blockdata="0x2" name="Double Slab, Birch Wood" />
@@ -539,7 +539,7 @@
       <blockvariant blockdata="0x4" name="Double Slab, Acacia Wood" />
       <blockvariant blockdata="0x5" name="Double Slab, Dark Oak Wood" />
       <blockvariant blockdata="0x8" name="Double Slab, Upper Oak Wood" /> <!-- how is this even possible?? -->
-      <blockvariant blockdata="0x9" name="Double Slab, Upper Spruce Wood" /> <!-- "doueble upper" ?? -->
+      <blockvariant blockdata="0x9" name="Double Slab, Upper Spruce Wood" /> <!-- "double upper" ?? -->
       <blockvariant blockdata="0xA" name="Double Slab, Upper Birch Wood" /> <!-- I have to assume these are formulaic generation -->
       <blockvariant blockdata="0xB" name="Double Slab, Upper Jungle Wood" /> <!-- and therefore will never actually occur in a real file -->
       <blockvariant blockdata="0xC" name="Double Slab, Upper Acacia Wood" /> <!-- double stone slabs all have the same issue -->

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -237,7 +237,7 @@
     <block id="0x2D" name="Brick Block" uname="minecraft:brick_block" color="0x9a0b18" />
     <block id="0x2E" name="TNT" uname="minecraft:tnt" color="0xee6f66" solid="0" opaque="0" spawnable="0" />
     <block id="0x2F" name="Bookshelf" uname="minecraft:bookshelf" color="0xa27826" />
-    <block id="0x30" name="Mossy Cobblestone" uname="minecraft:mossy_cobblestone" color="0x8a9e90" />
+    <block id="0x30" name="Mossy Cobblestone" uname="minecraft:mossy_cobblestone" color="0x8a9d9f" />
     <block id="0x31" name="Obsidian" uname="minecraft:obsidian" color="0xc2a6c1" />
     <block id="0x32" name="Torch" uname="minecraft:torch" color="0xfffd00" solid="0" opaque="0" spawnable="0">
       <blockvariant blockdata="0x0" name="Torch" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -46,7 +46,7 @@
       <blockvariant blockdata="0x1" name="Dirt, Coarse" />
     </block>
     <block id="0x04" name="Cobblestone" uname="minecraft:cobblestone" color="0xc0c0c0" />
-    <block id="0x05" name="Wood Planks" uname="minecraft:planks" color="0x696a2d">
+    <block id="0x05" name="Wood Planks" uname="minecraft:planks" color="0x69692d">
       <blockvariant blockdata="0x0" name="Planks, Oak" />
       <blockvariant blockdata="0x1" name="Planks, Spruce" />
       <blockvariant blockdata="0x2" name="Planks, Birch" />
@@ -249,7 +249,7 @@
     </block>
     <block id="0x33" name="Fire" uname="minecraft:fire" color="0xff1d32" solid="0" opaque="0" spawnable="0" />
     <block id="0x34" name="Spawner" uname="minecraft:mob_spawner" color="0x930a91" /> <!-- *E -->
-    <block id="0x35" name="Oak Stairs" uname="minecraft:oak_stairs" color="0x696b2d" spawnable="0"> <!-- *S -->
+    <block id="0x35" name="Oak Stairs" uname="minecraft:oak_stairs" color="0x696a2a" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Oak Stairs, East" />
       <blockvariant blockdata="0x1" name="Oak Stairs, West" />
       <blockvariant blockdata="0x2" name="Oak Stairs, South" />
@@ -404,7 +404,7 @@
     <block id="0x83" name="Tripwire Hook" uname="minecraft:tripwire_hook" color="0x454545" solid="0" /> <!-- *S 0.13 -->
     <block id="0x84" name="Tripwire" uname="minecraft:tripwire;minecraft:tripWire" color="0xa7a7a7" solid="0" /> <!-- *I *S 0.13 -->
     <block id="0x85" name="Block of Emerald" uname="minecraft:emerald_block" color="0x6dbc73" />
-    <block id="0x86" name="Stairs, Spruce Wood" uname="minecraft:spruce_stairs" color="0x696c2d" spawnable="0"> <!-- *S -->
+    <block id="0x86" name="Stairs, Spruce Wood" uname="minecraft:spruce_stairs" color="0x696b2b" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Spruce Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Spruce Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Spruce Wood, South" />
@@ -424,7 +424,7 @@
       <blockvariant blockdata="0x6" name="Stairs, Birch Wood, South (Upside-down)" spawnable="1" />
       <blockvariant blockdata="0x7" name="Stairs, Birch Wood, North (Upside-down)" spawnable="1" />
     </block>
-    <block id="0x88" name="Stairs, Jungle Wood" uname="minecraft:jungle_stairs" color="0x696e2d" spawnable="0"> <!-- *S -->
+    <block id="0x88" name="Stairs, Jungle Wood" uname="minecraft:jungle_stairs" color="0x696e2e" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Jungle Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Jungle Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Jungle Wood, South" />
@@ -639,7 +639,7 @@
     <block id="0xA5" name="Slime Block" uname="minecraft:slime" color="0x34e734" opaque="0" spawnable="1" /> <!-- 0.14 -->
     <block id="0xA6" name="Glow Stick" uname="minecraft:glow_stick" color="0x7fff00" opaque="0" spawnable="1" /> <!-- 0.14 -->
     <block id="0xA7" name="Trapdoor, Iron" uname="minecraft:iron_trapdoor" color="0xcfcccc" opaque="0" spawnable="0" /> <!-- *S 0.13 -->
-    <block id="0xA8" name="Prismarine" uname="minecraft:prismarine" color="0x008080" opaque="1" spawnable="1"> <!-- *S 0.16 --> <!-- todo color -->
+    <block id="0xA8" name="Prismarine" uname="minecraft:prismarine" color="0x008081" opaque="1" spawnable="1"> <!-- *S 0.16 -->
       <blockvariant blockdata="0x0" color="0x008080" name="Prismarine, Rough" /> <!-- 0.16 -->
       <blockvariant blockdata="0x1" color="0x004040" name="Prismarine, Dark" /> <!-- 0.16 -->
       <blockvariant blockdata="0x2" color="0x006060" name="Prismarine, Bricks" /> <!-- 0.16 -->
@@ -671,13 +671,13 @@
       <blockvariant blockdata="0x0" color="0x57d657" name="Sunflower" />
       <blockvariant blockdata="0x1" color="0x1f821f" name="Lilac" />
       <blockvariant blockdata="0x2" color="0x5f9ea0" name="Double Tallgrass" />
-      <blockvariant blockdata="0x3" color="0x5f9ea0" name="Large Fern" />
+      <blockvariant blockdata="0x3" color="0x5f9ea2" name="Large Fern" />
       <blockvariant blockdata="0x4" color="0xbc8f8f" name="Rose Bush" />
       <blockvariant blockdata="0x5" color="0x2dba2d" name="Peony" />
       <blockvariant blockdata="0x8" color="0xffff00" name="Sunflower (top)" />
       <blockvariant blockdata="0x9" color="0xee82ee" name="Lilac (top)" />
-      <blockvariant blockdata="0xA" color="0x5f9ea0" name="Double Tallgrass (top)" />
-      <blockvariant blockdata="0xB" color="0x5f9ea0" name="Large Fern (top)" />
+      <blockvariant blockdata="0xA" color="0x5f9ea1" name="Double Tallgrass (top)" />
+      <blockvariant blockdata="0xB" color="0x5f9ea3" name="Large Fern (top)" />
       <blockvariant blockdata="0xC" color="0xdc143c" name="Rose Bush (top)" />
       <blockvariant blockdata="0xD" color="0xd87093" name="Peony (top)" />
       <blockvariant blockdata="0xE" color="0xff00ff" name="Unknown Tall Flower (0xE)" />
@@ -779,7 +779,7 @@
       <blockvariant blockdata="0x6" name="Purpur, Pillar (East/West)" />
       <blockvariant blockdata="0xa" name="Purpur, Pillar (North/South)" />
     </block>
-    <block id="0xCA" name="Red Torch" uname= "minecraft:colored_torch_rg" color="0x963429" spawnable="0" /> <!-- *S --> <!-- 0.17 --> <!-- todo color -->
+    <block id="0xCA" name="Red Torch" uname= "minecraft:colored_torch_rg" color="0x963428" spawnable="0" /> <!-- *S --> <!-- 0.17 -->
     <block id="0xCB" name="Stairs, Purpur" uname= "minecraft:purpur_stairs" color="0xf4c4f4" spawnable="0"> <!-- *S --> <!-- 0.17 --> <!-- todo color -->
       <blockvariant blockdata="0x0" name="Stairs, Purpur, East" />
       <blockvariant blockdata="0x1" name="Stairs, Purpur, West" />
@@ -1160,7 +1160,7 @@
     <block id="0x1a2" name="Bamboo" uname="minecraft:bamboo" color="0x1DCE32" />
     <block id="0x1a3" name="Bamboo Sapling" uname="minecraft:bamboo_sapling" color="0x1DCE33" />
     <block id="0x1a4" name="Scaffolding" uname="minecraft:scaffolding" color="0xc5b023" />
-    <block id="0x1a5" name="Stone Slab(4)" uname="minecraft:stone_slab4" color="0x8a9e91" opaque="0" spawnable="0">
+    <block id="0x1a5" name="Stone Slab(4)" uname="minecraft:stone_slab4" color="0x8b9e91" opaque="0" spawnable="0">
       <blockvariant blockdata="0x0" name="Slab, Mossy Stone Brick" />
       <blockvariant blockdata="0x1" name="Slab, Smooth Quartz" />
       <blockvariant blockdata="0x2" name="Slab, Stone" />
@@ -1232,7 +1232,7 @@
     <block id="0x1AF" name="Smooth Red SandStone Stairs" uname="minecraft:smooth_red_sandstone_stairs" color="0xC38439" spawnable="0"/>
     <block id="0x1B0" name="Smooth SandStone Stairs" uname="minecraft:smooth_sandstone_stairs" color="0xC3843A" spawnable="0"/>
     <block id="0x1B1" name="End Stone Brick Stairs" uname="minecraft:end_brick_stairs" color="0xefe9a4" spawnable="0"/>
-    <block id="0x1B2" name="Mossy Cobblestone Stairs" uname="minecraft:mossy_cobblestone_stairs" color="0x8a9e93" spawnable="0"/>
+    <block id="0x1B2" name="Mossy Cobblestone Stairs" uname="minecraft:mossy_cobblestone_stairs" color="0x8aae93" spawnable="0"/>
     <block id="0x1B3" name="Stone Stairs" uname="minecraft:normal_stone_stairs" color="0x8a9e94" spawnable="0">
       <blockvariant blockdata="0x0" name="Stairs, Stone, East" />
       <blockvariant blockdata="0x1" name="Stairs, Stone, West" />
@@ -1243,19 +1243,19 @@
       <blockvariant blockdata="0x6" name="Stairs, Stone, South (Upside-down)" spawnable="1" />
       <blockvariant blockdata="0x7" name="Stairs, Stone, North (Upside-down)" spawnable="1" />
     </block>
-    <block id="0x1B4" name="Spruce Standing Sign" uname="minecraft:spruce_standing_sign" color="0x795f43" />
+    <block id="0x1B4" name="Spruce Standing Sign" uname="minecraft:spruce_standing_sign" color="0x795e43" />
     <block id="0x1B5" name="Spruce Wall Sign" uname="minecraft:spruce_wall_sign" color="0x795f44" />
     <block id="0x1B6" name="Smooth Stone" uname="minecraft:smooth_stone" color="0x8a9e93" />
     <block id="0x1B7" name="Red Nether Brick Stairs" uname="minecraft:red_nether_brick_stairs" color="0xbaf5f2" />
-    <block id="0x1B8" name="Smooth Quartz Stairs" uname="minecraft:smooth_quartz_stairs" color="0xfffff2" />
+    <block id="0x1B8" name="Smooth Quartz Stairs" uname="minecraft:smooth_quartz_stairs" color="0xfffef2" />
     <block id="0x1B9" name="Birch Standing Sign" uname="minecraft:birch_standing_sign" color="0x916601" />
     <block id="0x1BA" name="Birch Wall Sign" uname="minecraft:birch_wall_sign" color="0x916602" />
     <block id="0x1BB" name="Jungle Standing Sign" uname="minecraft:jungle_standing_sign" color="0x926603" />
     <block id="0x1BC" name="Jungle Wall Sign" uname="minecraft:jungle_wall_sign" color="0x926604" />
-    <block id="0x1BD" name="Acacia Standing Sign" uname="minecraft:acacia_standing_sign" color="0x69702b" />
-    <block id="0x1BE" name="Acacia Wall Sign" uname="minecraft:acacia_wall_sign" color="0x69702e" />
-    <block id="0x1BF" name="Darkoak Standing Sign" uname="minecraft:darkoak_standing_sign" color="0x69722a" />
-    <block id="0x1C0" name="Darkoak Wall Sign" uname="minecraft:darkoak_wall_sign" color="0x69722d" />
+    <block id="0x1BD" name="Acacia Standing Sign" uname="minecraft:acacia_standing_sign" color="0x70702b" />
+    <block id="0x1BE" name="Acacia Wall Sign" uname="minecraft:acacia_wall_sign" color="0x70702e" />
+    <block id="0x1BF" name="Darkoak Standing Sign" uname="minecraft:darkoak_standing_sign" color="0x68722a" />
+    <block id="0x1C0" name="Darkoak Wall Sign" uname="minecraft:darkoak_wall_sign" color="0x68722d" />
     <block id="0x1c1" name="lectern" uname="minecraft:lectern" color="0x895c27" />
     <block id="0x1c2" name="Grindstone" uname="minecraft:grindstone" color="0x808180" />
     <block id="0x1c3" name="Blast Furnace" uname="minecraft:blast_furnace" color="0xe54e27" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -5,7 +5,7 @@
       and:         http://minecraft.gamepedia.com/Data_values#Block_IDs
       and:         http://minecraft.gamepedia.com/Opacity
       and:         https://gist.github.com/jocopa3/f8c9f9158ede0e9d057781188ba440f5
-      
+
       blocklist: mcpe blocks
       id - mcpe block id (hex)
       name - pretty name of block (used for labels etc)
@@ -15,16 +15,16 @@
       opaque - flag for opaque/non-opaque (default is opaque)
       liquid - flag for liquid/non-liquid (default is non-liquid)
       spawnable - flag for if a mob can spawn on the block ABOVE this block (default is spawnable)
-      
+
       can have variants with these fields:
       blockdata - blockdata value for this variant
       name - name for variant
       color - color for variant (otherwise it will be based on containing block element)
-      
+
       note: *I *S *E *D etc are markers for blocks that have more info in block_data or damage etc
       note: it is important for the web ui that colors are unique (e.g. jshint out1.js)
       note: items with "TBD" in their name need investigation re MCPE value/name vs MCPC
-      
+
       todo - would be cool to find a definitive list of colors for blocks
       todo - could rip images from apk and get an avg color?
       todo - add variants for stairs (e/w/s/n + upside-down)
@@ -645,7 +645,7 @@
       <blockvariant blockdata="0x2" color="0x006060" name="Prismarine, Bricks" /> <!-- 0.16 -->
     </block>
     <block id="0xA9" name="Sea Lantern" uname="minecraft:sealantern" color="0x00cccc" opaque="1" spawnable="1" /> <!-- *S 0.16 --> <!-- todo color -->
-    <block id="0xAA" name="Hay Bale" uname="minecraft:hay_block" color="0xd8d385" /> 
+    <block id="0xAA" name="Hay Bale" uname="minecraft:hay_block" color="0xd8d385" />
     <block id="0xAB" name="Carpet" uname="minecraft:carpet" solid="0" opaque="0" spawnable="0"> <!-- *S *B -->
       <blockvariant blockdata="0x0" color="0xDDDDDD" dcolor="7" name="Carpet, White" />
       <blockvariant blockdata="0x1" color="0xDB7D3E" dcolor="7" name="Carpet, Orange" />
@@ -664,7 +664,7 @@
       <blockvariant blockdata="0xe" color="0x963430" dcolor="7" name="Carpet, Red" />
       <blockvariant blockdata="0xf" color="0x191616" dcolor="7" name="Carpet, Black" />
     </block>
-    <block id="0xAC" name="Terracotta" uname="minecraft:terracotta;minecraft:hardened_clay" color="0xb75252" /> 
+    <block id="0xAC" name="Terracotta" uname="minecraft:terracotta;minecraft:hardened_clay" color="0xb75252" />
     <block id="0xAD" name="Block of Coal" uname="minecraft:coal_block" color="0x585858" />
     <block id="0xAE" name="Packed Ice" uname="minecraft:packed_ice" color="0x02cffc" opaque="0" />
     <block id="0xAF" name="Large Flowers" uname="minecraft:double_plant" color="0xe4208a" solid="0" opaque="0" spawnable="0"> <!-- *B -->
@@ -762,7 +762,7 @@
       <blockvariant blockdata="0xd" color="0x35461B" dcolor="8" name="Hardened Stained Glass Pane, Green" />
       <blockvariant blockdata="0xe" color="0x963430" dcolor="8" name="Hardened Stained Glass Pane, Red" />
       <blockvariant blockdata="0xf" color="0x191616" dcolor="8" name="Hardened Stained Glass Pane, Black" />
-    </block>    
+    </block>
     <block id="0xC0" name="Heat Block" uname="minecraft:chemical_heat" color="0xfc5c1e" />
     <block id="0xC1" name="Door, Spruce" uname="minecraft:spruce_door" color="0x805f0d" solid="0" opaque="0" spawnable="0" /> <!-- *S *I 0.13 -->
     <block id="0xC2" name="Door, Birch" uname="minecraft:birch_door" color="0x77622e" solid="0" opaque="0" spawnable="0" /> <!-- *S *I 0.13 -->
@@ -796,9 +796,9 @@
     <block id="0xCF" name="Frosted Ice" uname="minecraft:frosted_ice" color="0xe0e0f1" opaque="0" />
     <block id="0xD0" name="End Rod" uname="minecraft:end_rod" color="0xf7f7f6" spawnable="0" /> <!-- *S --> <!-- 0.17 --> <!-- todo color -->
     <block id="0xD1" name="End Gateway" uname="minecraft:end_gateway" color="0x545454" spawnable="0" /> <!-- *S --> <!-- 0.17 --> <!-- todo color -->
-    <block id="0xD2" name="Allow Block" uname="minecraft:allow" spawnable="0" /> <!-- EDU -->
-    <block id="0xD3" name="Deny Block" uname="minecraft:deny" spawnable="0" /> <!-- EDU -->
-    <block id="0xD4" name="Border Block" uname="minecraft:border_block" spawnable="0" /> <!-- EDU -->
+    <block id="0xD2" name="Allow Block" uname="minecraft:allow" color="0x02FF02" spawnable="0" /> <!-- EDU -->
+    <block id="0xD3" name="Deny Block" uname="minecraft:deny" color="0xff0202" spawnable="0" /> <!-- EDU -->
+    <block id="0xD4" name="Border Block" uname="minecraft:border_block" color="0x888888" spawnable="0" /> <!-- EDU -->
     <block id="0xD5" name="Magma Block" uname="minecraft:magma" color="0xd65c0b" />
     <block id="0xD6" name="Nether wart Block" uname="minecraft:nether_wart_block" color="0xd65c0c" />
     <block id="0xD7" name="Red Nether Brick" uname="minecraft:red_nether_brick" color="0x230203" />
@@ -832,7 +832,7 @@
     <block id="0xE3" name="Glazed Terracotta, Gray" uname="minecraft:gray_glazed_terracotta;minecraft:glazedterracotta.gray" color="0x404039" />
     <block id="0xE4" name="Glazed Terracotta, Light Gray" uname="minecraft:silver_glazed_terracotta;minecraft:glazedterracotta.silver" color="0x9AA1A0" />
     <block id="0xE5" name="Glazed Terracotta, Cyan" uname="minecraft:cyan_glazed_terracotta;minecraft:glazedterracotta.cyan" color="0x2E6E88" />
-    <block id="0xE6" name="Glazed Terracotta, Chalkboard" uname="minecraft:chalkboard;minecraft:glazedterracotta.chalkboard" spawnable="0" /> <!-- EDU -->
+    <block id="0xE6" name="Glazed Terracotta, Chalkboard" uname="minecraft:chalkboard;minecraft:glazedterracotta.chalkboard" color="0x005F49" spawnable="0" /> <!-- EDU -->
     <block id="0xE7" name="Glazed Terracotta, Blue" uname="minecraft:blue_glazed_terracotta;minecraft:glazedterracotta.blue" color="0x2E388C" />
     <block id="0xE8" name="Glazed Terracotta, Brown" uname="minecraft:brown_glazed_terracotta;minecraft:glazedterracotta.brown" color="0x4F321D" />
     <block id="0xE9" name="Glazed Terracotta, Green" uname="minecraft:green_glazed_terracotta;minecraft:glazedterracotta.green" color="0x35461A" />
@@ -874,7 +874,7 @@
       <blockvariant blockdata="0xe" color="0x963430" dcolor="6" name="Concrete Powder, Red" />
       <blockvariant blockdata="0xf" color="0x191616" dcolor="6" name="Concrete Powder, Black" />
     </block>
-    <block id="0xEE" name="Compound Creator" uname="minecraft:chemistry_table" color="0x9AA1A0" spawnable="0" /> <!-- *S --> <!-- 0.17 -->
+    <block id="0xEE" name="Compound Creator" uname="minecraft:chemistry_table" color="0x9AA1A1" spawnable="0" /> <!-- *S --> <!-- 0.17 -->
     <block id="0xEF" name="Underwater Torch" uname="minecraft:underwater_torch" color="0xDB7D3C" spawnable="0" /> <!-- *S --> <!-- 0.17 -->
     <block id="0xF0" name="Chorus Plant" uname="minecraft:chorus_plant" color="0x591062" spawnable="0" /> <!-- *S --> <!-- 0.17 --> <!-- todo color -->
     <block id="0xF1" name="Stained Glass" uname="minecraft:stained_glass"> <!-- *B --> <!-- 0.17 --> <!-- todo colors -->
@@ -895,7 +895,7 @@
       <blockvariant blockdata="0xe" color="0x963430" dcolor="3" name="Stained Glass, Red" />
       <blockvariant blockdata="0xf" color="0x191616" dcolor="3" name="Stained Glass, Black" />
     </block>
-    <block id="0xF2" name="Camera" uname="minecraft:camera" spawnable="0" /> <!-- EDU -->
+    <block id="0xF2" name="Camera" uname="minecraft:camera" color="0xCC0000" spawnable="0" /> <!-- EDU -->
     <block id="0xF3" name="Podzol" uname="minecraft:podzol" color="0x45390a" />
     <block id="0xF4" name="Beetroot" uname="minecraft:beetroot" color="0xd03388" solid="0" opaque="0" spawnable="0" /> <!-- *S *I -->
     <block id="0xF5" name="Stone Cutter" uname="minecraft:stonecutter" color="0xb2aea5" />
@@ -905,9 +905,9 @@
       <blockvariant blockdata="0x1" name="Nether Reactor Core (Active)" />
       <blockvariant blockdata="0x2" name="Nether Reactor Core (Cooled)" />
     </block>
-    <block id="0xF8" name="Update Game Block (update!) [note 1]" uname="minecraft:info_update" /> <!-- todo -->
-    <block id="0xF9" name="Update Game Block (ate!upd)" uname="minecraft:info_update2" /> <!-- todo -->
-    <block id="0xFA" name="Block moved by Pistion" uname="minecraft:movingblock;minecraft:movingBlock" opaque="0" spawnable="0" /> <!-- *S *E 0.16? -->
+    <block id="0xF8" name="Update Game Block (update!) [note 1]" uname="minecraft:info_update" color="0xCC0001" /> <!-- todo -->
+    <block id="0xF9" name="Update Game Block (ate!upd)" uname="minecraft:info_update2" color="0xCC0100" /> <!-- todo -->
+    <block id="0xFA" name="Block moved by Piston" uname="minecraft:movingblock;minecraft:movingBlock" color="0x8a9d9a" opaque="0" spawnable="0" /> <!-- *S *E 0.16? -->
     <block id="0xFB" name="Observer" uname="minecraft:observer" color="0xa13d3d" opaque="0" spawnable="0"> <!-- *S *E 0.15 -->
       <blockvariant blockdata="0x0" name="Observer (Down)" />
       <blockvariant blockdata="0x1" name="Observer (Up)" />
@@ -919,7 +919,7 @@
     <block id="0xFC" name="Structure Block" uname="minecraft:structure_block" color="0x6de0af" /> <!-- todo -->
     <block id="0xFD" name="Hardened Glass" uname="minecraft:hard_glass" color="0x6de0ae" /> <!-- todo -->
     <block id="0xFE" name="Hard Stained Glass" uname="minecraft:hard_stained_glass" color="0x66bd97" /> <!-- todo -->
-    <block id="0xFF" name="info_reserved6" uname="minecraft:reserved6" /> <!-- todo -->
+    <block id="0xFF" name="info_reserved6" uname="minecraft:reserved6" color="0x8cca1e" /> <!-- todo -->
     <block id="0x101" name="Prismarine Stairs" uname="minecraft:prismarine_stairs" color="0x1c7955" >
       <blockvariant blockdata="0x0" name="Prismarine Stairs, East" />
       <blockvariant blockdata="0x1" name="Prismarine Stairs, West" />
@@ -957,7 +957,7 @@
     <block id="0x108" name="Stripped Dark Oak Log" uname="minecraft:stripped_dark_oak_log" color="0x5d390f" />
     <block id="0x109" name="Stripped Oak Log" uname="minecraft:stripped_oak_log" color="0xa47845" />
     <block id="0x10a" name="Blue Ice" uname="minecraft:blue_ice" color="0x6acaea" />
-    
+
     <block id="0x10B" name="Hydrogen" uname="minecraft:element_1 " color="0xB675AD" />
     <block id="0x10C" name="Helium" uname="minecraft:element_2 " color="0xB675AE" />
     <block id="0x10D" name="Lithium" uname="minecraft:element_3 " color="0xB675AF" />
@@ -1081,7 +1081,7 @@
       <blockvariant blockdata="0x0" name="Sea Grass0" />
       <blockvariant blockdata="0x1" name="Sea grass1" />
       <blockvariant blockdata="0x2" name="Sea Grass2" />
-    </block>	
+    </block>
     <block id="0x182" name="Coral" uname="minecraft:coral" color="0x0e1c40" opaque="0" spawnable="0" />
     <block id="0x183" name="Coral Block" uname="minecraft:coral_block" color="0x0e1c41" opaque="0" spawnable="0" />
     <block id="0x184" name="Coral Fan" uname="minecraft:coral_fan" color="0x0e1c42" opaque="0" spawnable="0" />
@@ -1400,11 +1400,11 @@
 
   <!--
       mostly from: http://minecraft.gamepedia.com/Data_values_%28Pocket_Edition%29
-      
+
       itemlist: mcpe items
       id - mcpe item id (hex)
       name - name of item
-      
+
       todo: some items use 'damage' field to store info
   -->
   <!-- todo search on (uname="minecraft:") for items that need attention -->
@@ -1844,7 +1844,7 @@
       <itemvariant extradata="0x25" name="Splash Potion of Turtle Master (0:20)" uname="minecraft:" />
       <itemvariant extradata="0x26" name="Splash Potion of Turtle Master (0:40)" uname="minecraft:" />
       <itemvariant extradata="0x27" name="Splash Potion of Turtle Master II (0:20)" uname="minecraft:" />
-    </item>    
+    </item>
     <item id="0x1B9" name="Lingering Potion" uname="minecraft:lingering_potion"> <!-- *B --> <!-- 0.17 -->
       <!-- todo these are copied from splash, not checked yet -->
       <itemvariant extradata="0x00" name="Lingering Water Bottle" uname="minecraft:" />
@@ -1887,7 +1887,7 @@
       <itemvariant extradata="0x25" name="Lingering Potion of Turtle Master (0:20)" uname="minecraft:" />
       <itemvariant extradata="0x26" name="Lingering Potion of Turtle Master (0:40)" uname="minecraft:" />
       <itemvariant extradata="0x27" name="Lingering Potion of Turtle Master II (0:20)" uname="minecraft:" />
-    </item>    
+    </item>
     <item id="0x1BA" name="Sparkler" uname="minecraft:sparkler" />
     <item id="0x1BB" name="Minecart with Command Block" uname="minecraft:command_block_minecart" />
     <item id="0x1BC" name="Elytra" uname="minecraft:elytra" /> <!-- *B --> <!-- 0.17 -->
@@ -1904,7 +1904,7 @@
       <itemvariant extradata="0x0" name="1x1 Chalkboard" uname="minecraft:" /> <!-- EDU -->
       <itemvariant extradata="0x1" name="2x1 Chalkboard" uname="minecraft:" /> <!-- EDU -->
       <itemvariant extradata="0x2" name="3x1 Chalkboard" uname="minecraft:" /> <!-- EDU -->
-    </item> 
+    </item>
     <item id="0x1C7" name="Trident" uname="minecraft:trident" />
     <item id="0x1C8" name="Portfolio" uname="minecraft:portfolio" /> <!-- EDU -->
     <item id="0x1C9" name="Beetroot" uname="minecraft:beetroot" />
@@ -1965,7 +1965,7 @@
 
   <!--
       mostly from: http://minecraft.gamepedia.com/Data_values_%28Pocket_Edition%29
-      
+
       entitylist: mcpe entities
       id - mcpe entity id (hex)
       uname - mcpe entity id (string)
@@ -2044,7 +2044,7 @@
     <entity id="0x43" uname="minecraft:moving_block" name="Moving Block" />
     <entity id="0x44" uname="minecraft:xp_bottle" name="Thrown Experience Potion" />
     <entity id="0x45" uname="minecraft:xp_orb" name="Experience Orb" />    <!-- note: reverse engineered by me -->
-    <entity id="0x46" uname="minecraft:eye_of_ender_signal" name="Eye of Ender" /> 
+    <entity id="0x46" uname="minecraft:eye_of_ender_signal" name="Eye of Ender" />
     <entity id="0x47" uname="minecraft:ender_crystal" name="Ender Crystal" />
     <entity id="0x48" uname="minecraft:fireworks_rocket" name="Firework Rocket" />
     <entity id="0x49" uname="minecraft:thrown_trident" name="Trident" />
@@ -2080,16 +2080,16 @@
     <entity id="0x5b" uname="minecraft:wither_skull_dangerous" name="Blue Wither Skill" />
     <entity id="0x5d" uname="minecraft:lightning_bolt" name="Lightning Bolt" />
     <entity id="0x5e" uname="minecraft:small_fireball" name="Blaze fireball" />
-    <entity id="0x5f" uname="minecraft:area_effect_cloud" name="Area Effect Cloud" /> 
+    <entity id="0x5f" uname="minecraft:area_effect_cloud" name="Area Effect Cloud" />
     <entity id="0x60" uname="minecraft:hopper_minecart" name="Minecart with Hopper" />
     <entity id="0x61" uname="minecraft:tnt_minecart" name="Minecart with TNT" />
     <entity id="0x62" uname="minecraft:chest_minecart" name="Minecart with Chest" />
     <entity id="0x64" uname="minecraft:command_block_minecart" name="Minecart with Command Block" />
-    <entity id="0x65" uname="minecraft:lingering_potion" name="Lingering Potion" /> 
-    <entity id="0x66" uname="minecraft:llama_spit" name="Llama Spit" /> 
-    <entity id="0x67" uname="minecraft:evocation_fang" name="Evocation Fangs" /> 
-    <entity id="0x68" uname="minecraft:evocation_illager" name="Evoker" etype="H" /> 
-    <entity id="0x69" uname="minecraft:vex" name="Vex" etype="H" />  
+    <entity id="0x65" uname="minecraft:lingering_potion" name="Lingering Potion" />
+    <entity id="0x66" uname="minecraft:llama_spit" name="Llama Spit" />
+    <entity id="0x67" uname="minecraft:evocation_fang" name="Evocation Fangs" />
+    <entity id="0x68" uname="minecraft:evocation_illager" name="Evoker" etype="H" />
+    <entity id="0x69" uname="minecraft:vex" name="Vex" etype="H" />
     <entity id="0x6A" uname="minecraft:ice_bomb" name="Ice Bomb" />  <!-- EDU -->
     <entity id="0x6B" uname="minecraft:balloon" name="Balloon" />  <!-- EDU -->
     <entity id="0x6C" uname="minecraft:pufferfish" name="Pufferfish" etype="P" />
@@ -2115,7 +2115,7 @@
 
   <!--
       mostly from: http://minecraft.gamepedia.com/Data_values#Biome_IDs
-      
+
       biomelist: mcpe biomes
       id - mcpe biome id (hex)
       name - name of entity

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -249,7 +249,7 @@
     </block>
     <block id="0x33" name="Fire" uname="minecraft:fire" color="0xff1d32" solid="0" opaque="0" spawnable="0" />
     <block id="0x34" name="Spawner" uname="minecraft:mob_spawner" color="0x930a91" /> <!-- *E -->
-    <block id="0x35" name="Oak Stairs" uname="minecraft:oak_stairs" color="0x696a2a" spawnable="0"> <!-- *S -->
+    <block id="0x35" name="Oak Stairs" uname="minecraft:oak_stairs" color="0x696a20" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Oak Stairs, East" />
       <blockvariant blockdata="0x1" name="Oak Stairs, West" />
       <blockvariant blockdata="0x2" name="Oak Stairs, South" />
@@ -404,7 +404,7 @@
     <block id="0x83" name="Tripwire Hook" uname="minecraft:tripwire_hook" color="0x454545" solid="0" /> <!-- *S 0.13 -->
     <block id="0x84" name="Tripwire" uname="minecraft:tripwire;minecraft:tripWire" color="0xa7a7a7" solid="0" /> <!-- *I *S 0.13 -->
     <block id="0x85" name="Block of Emerald" uname="minecraft:emerald_block" color="0x6dbc73" />
-    <block id="0x86" name="Stairs, Spruce Wood" uname="minecraft:spruce_stairs" color="0x696b2b" spawnable="0"> <!-- *S -->
+    <block id="0x86" name="Stairs, Spruce Wood" uname="minecraft:spruce_stairs" color="0x696a29" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Spruce Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Spruce Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Spruce Wood, South" />
@@ -414,7 +414,7 @@
       <blockvariant blockdata="0x6" name="Stairs, Spruce Wood, South (Upside-down)" spawnable="1" />
       <blockvariant blockdata="0x7" name="Stairs, Spruce Wood, North (Upside-down)" spawnable="1" />
     </block>
-    <block id="0x87" name="Stairs, Birch Wood" uname="minecraft:birch_stairs" color="0x696d2d" spawnable="0"> <!-- *S -->
+    <block id="0x87" name="Stairs, Birch Wood" uname="minecraft:birch_stairs" color="0x696d20" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Birch Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Birch Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Birch Wood, South" />
@@ -424,7 +424,7 @@
       <blockvariant blockdata="0x6" name="Stairs, Birch Wood, South (Upside-down)" spawnable="1" />
       <blockvariant blockdata="0x7" name="Stairs, Birch Wood, North (Upside-down)" spawnable="1" />
     </block>
-    <block id="0x88" name="Stairs, Jungle Wood" uname="minecraft:jungle_stairs" color="0x696e2e" spawnable="0"> <!-- *S -->
+    <block id="0x88" name="Stairs, Jungle Wood" uname="minecraft:jungle_stairs" color="0x696d29" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Jungle Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Jungle Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Jungle Wood, South" />
@@ -546,7 +546,7 @@
       <blockvariant blockdata="0xD" name="Double Slab, Upper Dark Oak Wood" /> <!-- modern (nether) slabs are better setup -->
     </block>
     <!-- note: on MCPC 0x9e is "Dropper S E" -->
-    <block id="0x9E" name="Wooden Slab" uname="minecraft:wooden_slab" color="0x69732c" opaque="0" spawnable="0"> <!-- *B -->
+    <block id="0x9E" name="Wooden Slab" uname="minecraft:wooden_slab" color="0x687320" opaque="0" spawnable="0"> <!-- *B -->
       <blockvariant blockdata="0x0" name="Slab, Oak Wood" />
       <blockvariant blockdata="0x1" name="Slab, Spruce Wood" />
       <blockvariant blockdata="0x2" name="Slab, Birch Wood" />
@@ -626,7 +626,7 @@
       <blockvariant blockdata="0x6" name="Stairs, Acacia Wood, South (Upside-down)" spawnable="1" />
       <blockvariant blockdata="0x7" name="Stairs, Acacia Wood, North (Upside-down)" spawnable="1" />
     </block>
-    <block id="0xA4" name="Stairs, Dark Oak Wood" uname="minecraft:dark_oak_stairs" color="0x69722c" spawnable="0"> <!-- *S -->
+    <block id="0xA4" name="Stairs, Dark Oak Wood" uname="minecraft:dark_oak_stairs" color="0x697429" spawnable="0"> <!-- *S -->
       <blockvariant blockdata="0x0" name="Stairs, Dark Oak Wood, East" />
       <blockvariant blockdata="0x1" name="Stairs, Dark Oak Wood, West" />
       <blockvariant blockdata="0x2" name="Stairs, Dark Oak Wood, South" />

--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -1188,7 +1188,7 @@
       <blockvariant blockdata="0x6" name="Double Slab, Granite" />
       <blockvariant blockdata="0x7" name="Double Slab, Polished Granite" />
     </block>
-    <block id="0x1A7" name="Double Stone Slab(4)" uname="minecraft:double_stone_slab4" color="0x8a9e92">
+    <block id="0x1A7" name="Double Stone Slab(4)" uname="minecraft:double_stone_slab4" color="0x8a9e98">
       <blockvariant blockdata="0x0" name="Double Slab, Mossy Stone Brick" />
       <blockvariant blockdata="0x1" name="Double Slab, Smooth Quartz" />
       <blockvariant blockdata="0x2" name="Double Slab, Stone" />
@@ -1233,7 +1233,7 @@
     <block id="0x1B0" name="Smooth SandStone Stairs" uname="minecraft:smooth_sandstone_stairs" color="0xC3843A" spawnable="0"/>
     <block id="0x1B1" name="End Stone Brick Stairs" uname="minecraft:end_brick_stairs" color="0xefe9a4" spawnable="0"/>
     <block id="0x1B2" name="Mossy Cobblestone Stairs" uname="minecraft:mossy_cobblestone_stairs" color="0x8aae93" spawnable="0"/>
-    <block id="0x1B3" name="Stone Stairs" uname="minecraft:normal_stone_stairs" color="0x8a9e94" spawnable="0">
+    <block id="0x1B3" name="Stone Stairs" uname="minecraft:normal_stone_stairs" color="0x8a9e90" spawnable="0">
       <blockvariant blockdata="0x0" name="Stairs, Stone, East" />
       <blockvariant blockdata="0x1" name="Stairs, Stone, West" />
       <blockvariant blockdata="0x2" name="Stairs, Stone, South" />

--- a/src/xml/load_block.cc
+++ b/src/xml/load_block.cc
@@ -72,13 +72,13 @@ namespace mcpe_viz
                 }
                 if (var_color != -1) {
                     if (var_dcolor != -1) {
-                        var_color += var_dcolor;
+                        var_color += var_dcolor + 0x000100;
                     }
                     variant->color(var_color);
                 }
                 else {
                     auto new_color = local_be32toh(block->color());
-                    new_color += var_data;
+                    new_color += var_data + 0x000100;
                     variant->color(new_color);
                 }
 


### PR DESCRIPTION
the changes in this PR ensure we have unique colors for every block and variant in the XML.

This is accomplished by two things:
1. manual adjustments of declared colors
2. an automatic addition of 1 bit of green channel whenever we automatically calculate a color for a variant.

The legend generator and uniqueness validator from #87 was used to validate the uniqueness.