### PR TITLE
Implement local config

### DIFF
--- a/data/bedrock_viz.cfg
+++ b/data/bedrock_viz.cfg
@@ -1,73 +1,12 @@
-# config file for mcpe_viz
+# config file for bedrock_viz.cfg and bedrock_viz.local.cfg
+# everything after # on each line is a comment and will be ignored by the parser.
+# See USAGE.md for information on how the two files are used. Any value you see in this file
+# can also be used in your local configuration, where it is encouraged you make your changes.
 
 # hide blocks from overview map
 # hide-top: dimensionId blockId
-# (dimensionId=0 is overworld; dimensionId=1 is nether)
-# (blockId is from mcpe_viz.xml)
-
-# force blocks to appear on the overview map even if they are covered
-# force-top: dimensionId blockId
-# (dimensionId=0 is overworld; dimensionId=1 is nether)
-# (blockId is from mcpe_viz.xml)
-
-# add blocks to the geojson file so that they will be available in the web app
-# **PLEASE NOTE** adding common blocks will make your geojson file HUGE and possibly cause problems with the web app
-# geojson-block: dimensionId blockId
-# (dimensionId=0 is overworld; dimensionId=1 is nether)
-# (blockId is from mcpe_viz.xml)
-
-# add mappings for remote player id's
-# TIP: Put these mappings in 'mcpe_viz.local.cfg' and put that file in the same dir as the executable
-# player-id: playerId playerName
-# (playerId is the id string used in the leveldb files)
-# (playerName is the name you would like displayed in the web app)
-
-# in the nether, hide bedrock, netherrack and lava so that we can see more interesting details
-hide-top: 1 0x07 # bedrock
-hide-top: 1 0x57 # netherrack
-hide-top: 1 0x0a # lava
-hide-top: 1 0x0b # lava
-
-hide-top: 1 0x99 # quartz
-hide-top: 1 0x58 # soul sand
-hide-top: 1 0x0D # gravel
-hide-top: 1 0x33 # fire
-hide-top: 1 0x59 # glowstone
-
-
-# example of force-top - force spawners to top
-#force-top: 0 0x34
-#force-top: 1 0x34
-
-# force-top: 0 0x42 # rails
-# force-top: 0 0x1B # powered rails
-# force-top: 0 0x1C # detector rails
-# force-top: 0 0x7E # activator rails
-
-# add "special" blocks to the geojson file for use in the web app
-# For example, "End Portal Frame" block
-#geojson-block: 0 0x78   # end portal frame
-#geojson-block: 0 0x2E   # TNT
-#geojson-block: 0 0x78   # end portal frame
-# geojson-block: 0 0x23 # wool
-#geojson-block: 0 0xB0   # standing banner
-#geojson-block: 0 0xB1   # wall banner
-#geojson-block: 0 0x5A   # portal
-
-# geojson-block: 0 0x1A # bed
-# geojson-block: 0 0xAB # carpet
-# geojson-block: 0 0x42 # rails
-# geojson-block: 0 0x1B # powered rails
-# geojson-block: 0 0x1C # detector rails
-# geojson-block: 0 0x7E # activator rails
-# geojson-block: 0 0x38 # diamond ore
-# geojson-block: 0 0x93 # Iron Pressure Plate
-# geojson-block: 0 0x94 # Gold Pressure Plate
-# geojson-block: 0 0x48 # Stone Pressure Plate
-# geojson-block: 0 0x46 # Wooden Pressure Plate
-
-# example of player-id
-# player-id: 123456789 SomeUserName
+# (dimensionId=0 is overworld; 1 is nether; 2 is the end)
+# (blockId is from bedrock_viz.xml)
 
 # hide-top: 0 0x04 # cobblestone
 # hide-top: 0 0x0E # gold ore
@@ -77,7 +16,6 @@ hide-top: 1 0x59 # glowstone
 # hide-top: 0 0x38 # diamond ore
 # hide-top: 0 0x49 # redstone ore
 # hide-top: 0 0x81 # emerald ore
-
 # hide-top: 0 0x01 # stone
 # hide-top: 0 0x02 # grass block
 # hide-top: 0 0x03 # dirt
@@ -105,7 +43,7 @@ hide-top: 1 0x59 # glowstone
 # hide-top: 0 0x51 # cactus
 # hide-top: 0 0x52 # clay
 # hide-top: 0 0x53 # sugar cane
-# hide-top: 0 0x56 # pumkin
+# hide-top: 0 0x56 # pumpkin
 # hide-top: 0 0x61 # monster egg
 # hide-top: 0 0x63 # brown mushroom
 # hide-top: 0 0x64 # red mushroom
@@ -120,5 +58,68 @@ hide-top: 1 0x59 # glowstone
 # hide-top: 0 0xAC # hardened clay
 # hide-top: 0 0xAE # packed ice
 # hide-top: 0 0xAF # large flowers
-# hide-top: 0 0xB3 # red standstone
+# hide-top: 0 0xB3 # red sandstone
 # hide-top: 0 0xF3 # podzol
+
+# force blocks to appear on the overview map even if they are covered
+# force-top: dimensionId blockId
+# (dimensionId=0 is overworld; 1 is nether; 2 is the end)
+# (blockId is from bedrock_viz.xml)
+
+# example of force-top - force spawners to top
+# force-top: 0 0x34 # spawner in overworld
+# force-top: 1 0x34 # spawner in nether
+# force-top: 0 0x42 # rails
+# force-top: 0 0x1B # powered rails
+# force-top: 0 0x1C # detector rails
+# force-top: 0 0x7E # activator rails
+
+# add blocks to the geojson file so that they will be available in the web app
+# **PLEASE NOTE** adding common blocks will make your geojson file HUGE and probably cause problems with the web app
+# geojson-block: dimensionId blockId
+# (dimensionId=0 is overworld; 1 is nether; 2 is the end)
+# (blockId is from bedrock_viz.xml)
+
+# add "special" blocks to the geojson file for use in the web app, where they will appear as selections on the Blocks menu.
+# geojson-block: 0 0x78 # end portal frame in overworld
+# geojson-block: 2 0xD1 # end gateway in the end
+# geojson-block: 0 0x2E # TNT, a great sign of a trap!
+# geojson-block: 0 0xB0 # standing banner
+# geojson-block: 0 0xB1 # wall banner
+# geojson-block: 0 0x5A # portal frame in overworld
+# geojson-block: 1 0x5A # portal frame in the nether
+# geojson-block: 0 0x1A # bed
+# geojson-block: 0 0xAB # carpet
+# geojson-block: 0 0x42 # rails -- probably not the greatest way to find abandoned mines, as the volume of these will bloat the geojson file.
+# geojson-block: 0 0x1B # powered rails
+# geojson-block: 0 0x1C # detector rails
+# geojson-block: 0 0x7E # activator rails
+# geojson-block: 0 0x38 # diamond ore
+# geojson-block: 0 0x93 # Iron Pressure Plate
+# geojson-block: 0 0x94 # Gold Pressure Plate
+# geojson-block: 0 0x48 # Stone Pressure Plate
+# geojson-block: 0 0x46 # Wooden Pressure Plate
+
+# add mappings for remote player id's
+# player-id: playerId playerName
+# (playerId is the id string used in the leveldb files; or it is server_{some_uuid_the_game_assigns}... we need to document how to find that other than trial and error)
+# (playerName is the name you would like displayed in the web app)
+
+# example of player-id
+# player-id: 123456789 SomeUser
+# player-id: server_dd8c9a18-fb0c-43c9-bee1-4f012a9c56d7 SomeUserOnADedicatedServer
+
+
+# From here down are the defaults used by the visualizer, basically we just hide some things in the nether to make it easier to see in the overview map
+
+# in the nether, hide bedrock, netherrack and lava so that we can see more interesting details
+hide-top: 1 0x07 # bedrock
+hide-top: 1 0x57 # netherrack
+hide-top: 1 0x0a # lava
+hide-top: 1 0x0b # lava
+
+hide-top: 1 0x99 # quartz
+hide-top: 1 0x58 # soul sand
+hide-top: 1 0x0D # gravel
+hide-top: 1 0x33 # fire
+hide-top: 1 0x59 # glowstone

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,8 +1,6 @@
 # Program Usage 
 
 ## Program Options
-**Note: [=did] are optional dimension-ids - if not specified, do all dimensions; 0=Overworld; 1=Nether, 2=End)**
-**Example: `--biome=0 1`, `--biome 0 --biome 1`**
 | Parameter                                      | Description                                                  |
 |------------------------------------------------|--------------------------------------------------------------|
 | `db` (Required)                                | Directory which holds world files (level.dat is in this dir) |
@@ -10,8 +8,8 @@
 | `html`                                         | Create html and javascript files to use as a fancy viewer |
 | `html-most`                                    | Create html, javascript, and most image files to use as a fancy viewer |
 | `html-all`                                     | Create html, javascript, and *all* image files to use as a fancy viewer |
-| `no-tile`                                    | Generates single images instead of tiling output into smaller images. May cause loading problems if image size is > 4096px by 4096px |
-| `tile-size[=tilew,tileh]`                          | Changes tile sizes to specified dimensions (Default: 2048px by 2048px) |
+| `no-tile`                                      | Generates single images instead of tiling output into smaller images. May cause loading problems if image size is > 4096px by 4096px |
+| `tile-size[=tilew,tileh]`                      | Changes tile sizes to specified dimensions (Default: 2048px by 2048px) |
 | `slices[=did]`                                 | Create slices (one image for each layer) |
 | `movie[=did]`                                  | Create movie of layers |
 | `movie-dim x,y,w,h`                            | Integers describing the bounds of the movie (UL X, UL Y, WIDTH, HEIGHT) |
@@ -44,3 +42,30 @@
 | `leveldb-filter=i`                             | Bloom filter supposed to improve disk performance (default: 10) |
 | `leveldb-block-size=i`                         | The block size of leveldb (default: 4096) |
 | `leveldb-try-repair`                           | If the leveldb fails to open, this will attempt to repair the database. Data loss is possible, use carefully. |
+
+**Note: [=did] are optional dimension-ids - if not specified, do all dimensions; 0=Overworld; 1=Nether, 2=End)**
+**Example: `--biome=0 1`, `--biome 0 --biome 1`**
+
+## Configuration
+
+The visualizer will look for *up to two* configuration files, combining the results.
+The logic for this search is as follows:
+
+1. If the program is invoked with a `--cfg fn` option, that file path alone will be read for configuration information.
+No other file will be looked at for configuration if that file is found.
+
+2. When a configuration is not specified in the invocation, or the one specified is not found, the application will look for two files:
+
+   a. The base config file: `bedrock-viz.cfg`. This is the configuration as delivered with the visualizer, with basic settings that should produce an informative map out of the box. This file is subject to be replaced and changed from release to release.
+
+   b. Your local configuration additions: `bedrock-viz.local.cfg`. This file is where you should put your personal configuration. Document the player ids for the users in your world, configure the blocks that you don't care about, or that you find important enough to export as identifiable in the web app. The project does not provide this file, you own it entirely.
+
+   These two files will be searched for in three locations each, the first one found will be used:
+
+      1. Your home directory, as indicated by the `HOME` environment variable. In this location the file is expected to be a hidden file, eg prefixed with a `.`.
+
+      2. Your profile directory, as indicated by the `USERPROFILE` environment variable.  In this location the file is expected to be a hidden file, eg prefixed with a `.`.
+
+      3. The Application's Local Data directory, this is typically  `/usr/local/share/bedrock-viz/data/` on unix-like platforms, or the `data` directory that is in the same directory as the executable for Windows.
+
+   The local configuration additions **can not undo any settings in the base configuration.** They may only add to it. It is recommended therefore to keep the local configuration additions minimal. Should you find yourself needing to override a value from the base configuration, it is advised that you make a copy of the bae configuration file, make your changes there and specify that file with the `--cfg fn` option.


### PR DESCRIPTION
The config file and the Changelog both talk about a local configuration file. People keep trying to use it, see for example #3 . 

But the joke's on us... the code doesn't actually even try to load any file by that name. (Even accounting for the `mcpe-viz` vs `bedrock-viz` renaming.)

![That's not how this works, that's not how any of this works.](https://nerdcoloredglasses.files.wordpress.com/2015/09/thats-not-how-this-works.jpg)

So I added logic to look for both the base config `bedrock-viz.cfg` and a local additions `bedrock-viz.local.cfg` in the search path it was already using. Also refactored the code to be a little less bizarre. Also documented it for users.
