### PR TITLE
Adding support for Barrel tile entities.

### DIFF
--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -2204,6 +2204,17 @@ namespace mcpe_viz
                       0x31-te: NBT Decode End (1 tags)
                     */
                 }
+                else if (tileEntity->id == "Barrel") {
+                    if (tc.has_key("Items", nbt::tag_type::List)) {
+                        tileEntity->containerFlag = true;
+                        nbt::tag_list items = tc["Items"].as<nbt::tag_list>();
+                        for (const auto& iter : items) {
+                            nbt::tag_compound iitem = iter.as<nbt::tag_compound>();
+                            tileEntity->addItem(iitem);
+                        }
+                        parseFlag = true;
+                    }
+                }
 
                 else {
                     log::debug("Unknown tileEntity id=({})", tileEntity->id);

--- a/static/bedrock_viz.html.template
+++ b/static/bedrock_viz.html.template
@@ -201,6 +201,7 @@
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="SignBlank">Sign (Blank)</a></li>
 	    <li role="separator" class="divider"></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="Chest">Chest</a></li>
+	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="Barrel">Barrel</a></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="ShulkerBox">Shulker Box</a></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="EnderChest">Ender Chest</a></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="Hopper">Hopper</a></li>


### PR DESCRIPTION
Barrels are containers like chests, and you should be able to see the contents. Fixes #101 