### PR TITLE
improve version checking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(bedrock-viz VERSION 0.1.2)
+project(bedrock-viz VERSION 0.1.4)
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -2867,7 +2867,8 @@ function doCheckUpdate_getChangeLog(newVersion, releaseData) {
     var newVersionHighlight = releaseData['name'];
 
     // try to take the version off the front since it's redundant when displayed
-    var res = releaseData['name'].match(/v{newVersion}\s*-\s*(.+)/);
+    var re = new RegExp('v' + newVersion + '\\s*-\\s*(.+)');
+    var res = newVersionHighlight.match(re);
     if ( res ) {
         newVersionHighlight = res[1];
     }

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -2798,7 +2798,7 @@ function doTour(aboutFlag) {
             {
                 title: 'About Bedrock Viz',
                 content: '' +
-                    '<a href="https://github.com/bedrock-viz/bedrock-viz" target="_blank">Bedrock Viz on github<br/>' +
+                    '<a href="https://github.com/bedrock-viz/bedrock-viz" target="_blank">Bedrock Viz is developed on GitHub</a><br/>' +
                     'Version ' + creationBedrockVizVersion + '<br/>' +
                     'Please be sure to check back often for updates!</a><br/>' +
                     '<br/>' +
@@ -2807,7 +2807,7 @@ function doTour(aboutFlag) {
                     '<li><a href="http://getbootstrap.com/" target="_blank">Bootstrap</a></li>' +
                     '<li><a href="http://bootstraptour.com/" target="_blank">Bootstrap Tour</a></li>' +
                     '<li><a href="http://jquery.com/" target="_blank">jQuery</a></li>' +
-                    '<li><a href="https://github.com/Plethora777/mcpe_viz" target="_blank">Fork of MCPE Viz by Plethora777</li>' +
+                    '<li>Fork of <a href="https://github.com/Plethora777/mcpe_viz" target="_blank">MCPE Viz by Plethora777</a></li>' +
                     '</ul>' +
                     'Block and Item images are borrowed from the <a href="http://minecraft.gamepedia.com/" target="_blank">Minecraft Wiki</a>.  The textures themselves are copyright Mojang.'
             }
@@ -2832,8 +2832,7 @@ function doModal(title, body) {
     $('.modal').modal({});
 }
 
-function showUpdateInfo(newVersion, newVersionHighlight, changeLog) {
-    // todo - make the update checks come from https://api.github.com/repos/bedrock-viz/bedrock-viz/releases/latest for the latest version info.
+function showUpdateInfo(newVersion, newVersionHighlight, releaseData) {
     // todobig - make this a bootstrap dialog box that has a clickable link
     var isCurrent = newVersion == creationBedrockVizVersion;
     var title;
@@ -2847,7 +2846,7 @@ function showUpdateInfo(newVersion, newVersionHighlight, changeLog) {
     else
     {
         title = 'You are running the latest version';
-        msg = 'You are running the latest version: <b>v' + creationBedrockVizVersion + '</b><br/><br/>';
+        msg = 'You are running the latest released version: <b>v' + creationBedrockVizVersion + '</b><br/><br/>';
     }
 
     msg += '<div class="panel panel-default">' +
@@ -2857,42 +2856,28 @@ function showUpdateInfo(newVersion, newVersionHighlight, changeLog) {
            'View Changelog' +
            '</a></h4></div>' +
            '<div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">' +
-           '<div class="panel-body"><div class="pre-scrollable">' + changeLog + '</div></div>' +
+           '<div class="panel-body"><div class="pre-scrollable"><pre>' + releaseData['body'] + '</pre></div></div>' +
            '</div></div>' + 
-           (!isCurrent ? '<a target="_blank" href="https://github.com/bedrock-viz/bedrock-viz">Click here to go to GitHub and grab the update</a>' : '');
+           (!isCurrent ? '<a target="_blank" href="' + releaseData['html_url'] + '">Click here to go to GitHub and grab the update</a>' : '');
 
     doModal( title, msg);
 }
 
-function doCheckUpdate_getChangeLog(newVersion) {
-    // get data from github
-    var url = 'https://raw.githubusercontent.com/bedrock-viz/bedrock-viz/master/CHANGELOG.md';
+function doCheckUpdate_getChangeLog(newVersion, releaseData) {
+    var newVersionHighlight = releaseData['name'];
 
-    $.ajax({
-        type: 'GET',
-        url: url,
-        dataType: 'text',
-        cache: false,
-        success: function(result, textStatus, jqxhr) {
-            
-            // parse this: Latest Highlight: New stuff added");
-            var newVersionHighlight = '(See ChangeLog on GitHub)';
-            var res = result.match(/Latest highlight\s*:\s*(.+)/);
-            if ( res ) {
-                newVersionHighlight = res[1];
-            }
+    // try to take the version off the front since it's redundant when displayed
+    var res = releaseData['name'].match(/v{newVersion}\s*-\s*(.+)/);
+    if ( res ) {
+        newVersionHighlight = res[1];
+    }
 
-            showUpdateInfo(newVersion, newVersionHighlight, marked(result));
-        },
-        error: function(jqXHR, textStatus, errorThrown, execptionObject) {
-            showUpdateInfo(newVersion, '(Sorry, we had a problem checking the ChangeLog -- See ChangeLog on GitHub)', '(See ChangeLog on GitHub)');
-        }
-    });
+    showUpdateInfo(newVersion, newVersionHighlight, releaseData);
 }
 
 function doCheckUpdate() {
-    // get data from github
-    var url = 'https://raw.githubusercontent.com/bedrock-viz/bedrock-viz/master/CHANGELOG.md';
+    // get data from the latest published github release
+    var url = 'https://api.github.com/repos/bedrock-viz/bedrock-viz/releases/latest';
 
     $.ajax({
         type: 'GET',
@@ -2900,11 +2885,15 @@ function doCheckUpdate() {
         dataType: 'text',
         cache: false,
         success: function(result, textStatus, jqxhr) {
-            
-            // parse this: Latest release: X.Y.Z
-            var res = result.match(/Latest release\s*:\s*(\S+)/);
-            if ( res ) {
-                doCheckUpdate_getChangeLog(res[1]);
+            var releaseData = JSON.parse(result);
+            if ( releaseData ) {
+                var release = releaseData['tag_name'];
+                // try to take the v off the front to match our built in version
+                var res = releaseData['tag_name'].match(/v(\S+)/);
+                if (res) {
+                    release = res[1];
+                }
+                doCheckUpdate_getChangeLog(release, releaseData);
             } else {
                 doModal('Error', 'Sorry, failed to find version info on GitHub.');
             }


### PR DESCRIPTION
bug #103 indicated that I failed to increment the version number in the binary for 0.1.3.... so now that i've tracked down how that number comes to be, I've bumped it for 0.1.4. But then in looking into it I discovered that we were looking at the Changelog on master for the current released version... which seems all kinds of wrong. And sure enough there are some TODOs in the code talking about fetching it from the release api instead. So I did that. Also removed a second fetch of the data and just passed the fetched data in directly.

WBN if GitHub rendered the markdown in the release notes into html... but they don't so we end up with raw formatted text in the chaneglog view, which I think is fine given the details typically in there.

![Screenshot from 2021-07-01 15-51-01](https://user-images.githubusercontent.com/522147/124197842-4306f600-da84-11eb-87a7-a5aa6133004f.png)

I'd love some more experienced JS eyes on those bits in case I did something that's going to bite us on some obscure browser... or a trollish one. (Safari is the new IE?)
