### PR TITLE
don't remove the first three characters of lines 2+ on signs

### DIFF
--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -1376,10 +1376,6 @@ namespace mcpe_viz
                 std::string item;
                 char delim = '\n';
                 while (std::getline(ss, item, delim)) {
-                    if (textCount > 0) {
-                        // hacky: remove first 3 characters (minecraft control characters) of all lines but the first
-                        item.erase(0, 3);
-                    }
                     //fprintf(stderr,"sign text part [%s]\n", item.c_str());
                     text.push_back(item);
                     textCount++;


### PR DESCRIPTION
As issue #74 notes, there's a weird little piece of code that is blindly removing the first three characters of sign text on lines 2,3 and 4. The comments claim it is removing control characters, but I'm not seeing that be the case and can't find any reference to those control characters in other data sources. This just removes it. if there actually are some control characters in there it's going to break the geojson in a pretty obvious way.