### PR TITLE
Build and publish Docker image using GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Publish Docker Image
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  Docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: downcase REPO
+      run: |
+        echo "repo_downcase=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+    - name: Docker build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        push: true
+        tags: |
+          ghcr.io/${{ env.repo_downcase }}:${{ github.sha }}
+          ghcr.io/${{ env.repo_downcase }}:latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -111,3 +111,25 @@ jobs:
         mkdir build && cd build
         cmake .. -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -G "Visual Studio 16 2019" -A x64
         msbuild bedrock-viz.sln
+
+  Docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: downcase REPO
+      run: |
+        echo "repo_downcase=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+    - name: Docker build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        tags: ghcr.io/${{ env.repo_downcase }}:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ For macOS users(requires macOS 10.15 and above):
 For Linux users:
 * [Download the source](https://github.com/bedrock-viz/bedrock-viz/releases/download/v0.1.4/bedrock-viz_v0.1.4_linux.tar.gz) and compiling from source
 
+Alternatively, bedrock-viz is available as a Docker container. Usage example:
+
+```
+docker run --rm -v /path/to/public_html:/out -v /path/to/world:/world ghcr.io/bedrock-viz/bedrock-viz --db /world --out /out --html-all
+```
+
 **DO NOT RUN THIS ON YOUR ORIGINAL WORLD SAVES**
 
 **MAKE A BACKUP COPY OF YOUR DATA AND RUN THIS AGAINST THAT COPY ONLY**


### PR DESCRIPTION
This PR does 2 things:

* Adds a job to the existing workflow to test the Docker image build on push/pull request
* Adds a separate workflow for publishing images to the [container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) on merge to master

It also updates the README with a simple usage example. Once merged this PR will allow docker users to stay up to date with changes as they land.