### PR TITLE
deleting this block solves segmentation fault encountered with large maps

### DIFF
--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -420,18 +420,6 @@ namespace mcpe_viz
                     parseNbt_mVillages(tagList);
                 }
             }
-            else if (strncmp(key, "VILLAGE_", 8) == 0) {
-                // VILLAGE_07315855-d0e6-4fac-8b20-0c07cfad3d29_POI
-                char vid[37];
-                char rectype[9];
-                memcpy(vid, key + 8, 36);
-                vid[36] = '\0';
-                memcpy(rectype, key+45, key_size-45);
-                rectype[key_size-45] = '\0';
-                if (strncmp(rectype, "INFO", 5) == 0) {
-                    villages.push_back(vid);
-                }
-            }
             else if (strncmp(key, "game_flatworldlayers", key_size) == 0) {
                 // todobig -- what is it?
                 // example data (standard flat): 5b 37 2c 33 2c 33 2c 32 5d


### PR DESCRIPTION
Downloaded this tool yesterday. Very impressed by the code quality and open source support. Easy to build on Ubuntu.

Unfortunately, on large maps the generator would always fail with a segmentation fault.

```
[   info]     Unmapped remote player: server_0a3fe563-4062-42bf-aacc-39aecd766e25
[   info] Remote Player server_4352d7f1-b321-4a77-84a8-2e234260a736, unique:-4294962472
[   info]     Unmapped remote player: server_4352d7f1-b321-4a77-84a8-2e234260a736
[   info] Remote Player server_8c2e02f7-ce62-4748-a686-5c67a4ca690d, unique:-55834574847
[   info]     Unmapped remote player: server_8c2e02f7-ce62-4748-a686-5c67a4ca690d
[   info] Remote Player server_e2c44ae8-4034-4ad3-8889-64b1ad19942f, unique:-4294967295
[   info]     Unmapped remote player: server_e2c44ae8-4034-4ad3-8889-64b1ad19942f
[   info]   Processing records: 90000 / 122138 (73.7%)
[   info]   Processing records: 100000 / 122138 (81.9%)
[   info]   Processing records: 110000 / 122138 (90.1%)
[   info]   Processing records: 120000 / 122138 (98.2%)
Segmentation fault (core dumped)
```
The crash is occurring in world.cc
    `int32_t MinecraftWorld_LevelDB::dbParse()`

Bisecting the code in dbParse I was able to comment out a single block and prevent the crash from occurring.

What does the deleted block do? Why does it crash?