### PR TITLE
Chunk Processing: Add sub-chunk v9

### DIFF
--- a/include/world/misc.h
+++ b/include/world/misc.h
@@ -17,8 +17,8 @@ namespace mcpe_viz {
     uint8_t getBlockSkyLight_LevelDB_v3(const char* p, size_t plen, int32_t x, int32_t z, int32_t y);
     uint8_t getBlockBlockLight_LevelDB_v3(const char* p, size_t plen, int32_t x, int32_t z, int32_t y);
     int32_t
-        setupBlockVars_v7(const char* cdata, int32_t& blocksPerWord, int32_t& bitsPerBlock, bool& paddingFlag,
-            int32_t& offsetBlockInfoList, int32_t& extraOffset);
+        setupBlockVars_v7(const char* cdata, int32_t& blocksPerWord, int32_t& bitsPerBlock, int32_t& blockOffset,
+            int32_t& paletteOffset);
 //    uint8_t
 //        getBlockId_LevelDB_v7(const char* p, int blocksPerWord, int bitsPerBlock, int32_t x, int32_t z, int32_t y);
     uint8_t getColData_Height_LevelDB_v3(const char* buf, int32_t x, int32_t z);

--- a/src/world/chunk_data.cc
+++ b/src/world/chunk_data.cc
@@ -322,22 +322,22 @@ namespace mcpe_viz {
         // determine location of chunk palette
         int32_t blocksPerWord = -1;
         int32_t bitsPerBlock = -1;
-        bool paddingFlag = false;
-        int32_t offsetBlockInfoList = -1;
-        int32_t extraOffset = -1;
+        int32_t blockOffset = -1;
+        int32_t paletteOffset = -1;
+        
 
         //logger.msg(kLogWarning,"hey -- cdata %02x %02x %02x\n", cdata[0], cdata[1], cdata[2]);
-
-        if (setupBlockVars_v7(cdata, blocksPerWord, bitsPerBlock, paddingFlag, offsetBlockInfoList, extraOffset) !=
+        
+        if (setupBlockVars_v7(cdata, blocksPerWord, bitsPerBlock, blockOffset, paletteOffset) !=
             0) {
             return -1;
         }
 
         // read chunk palette and associate old-school block id's
         MyNbtTagList tagList;
-        int xoff = offsetBlockInfoList + 6 + extraOffset;
+        int xoff = paletteOffset+4;
 
-        parseNbtQuiet(&cdata[xoff], int32_t(cdata_size - xoff), cdata[offsetBlockInfoList + 3], tagList);
+        parseNbtQuiet(&cdata[xoff], int32_t(cdata_size - xoff), cdata[paletteOffset], tagList);
         //parseNbt("chunk-palette",&cdata[xoff], cdata_size-xoff, tagList);
 
         std::vector<int32_t> chunkBlockPalette_BlockId(tagList.size());
@@ -387,7 +387,8 @@ namespace mcpe_viz {
         for (int32_t cy = 0; cy < 16; cy++) {
             for (int32_t cx = 0; cx < 16; cx++) {
                 for (int32_t cz = 0; cz < 16; cz++) {
-                    paletteBlockId = getBlockId_LevelDB_v7(&cdata[2 + extraOffset],
+                    
+                    paletteBlockId = getBlockId_LevelDB_v7(&cdata[blockOffset],
                         blocksPerWord, bitsPerBlock, cx, cz, cy);
 
                     // look up blockId

--- a/src/world/misc.cc
+++ b/src/world/misc.cc
@@ -1,7 +1,6 @@
 #include "world/misc.h"
 
 #include "define.h"
-#include "math.h"
 #include "nbt.h"
 #include "logger.h"
 #include "utils/unknown_recorder.h"

--- a/src/world/misc.cc
+++ b/src/world/misc.cc
@@ -1,6 +1,7 @@
 #include "world/misc.h"
 
 #include "define.h"
+#include "math.h"
 #include "nbt.h"
 #include "logger.h"
 #include "utils/unknown_recorder.h"
@@ -247,67 +248,51 @@ namespace mcpe_viz {
     // todomajor -- see tomcc gist re multiple storages in ONE cubick chunk in version == 8
 
     int32_t
-        setupBlockVars_v7(const char* cdata, int32_t& blocksPerWord, int32_t& bitsPerBlock, bool& paddingFlag,
-            int32_t& offsetBlockInfoList, int32_t& extraOffset) {
+        setupBlockVars_v7(const char* cdata, int32_t& blocksPerWord, int32_t& bitsPerBlock, int32_t& blockOffset,
+            int32_t& paletteOffset) {
 
         int32_t v = -1;
+        int32_t wordCount = -1;
 
-        if (cdata[0] == 0x01) {
+        // Check sub-chunk version
+        switch (cdata[0]) {
+        case 0x01:
+            // v1 - [version:byte][block storage]
             v = cdata[1];
-            extraOffset = 0;
-        }
-        else {
-            // this is version 8+, cdata[1] contains the number of storage groups in this cubic chunk (can be more than 1)
-            v = cdata[2];
-            extraOffset = 1;
-        }
-
-        switch (v) {
-        case 0x02:
-            blocksPerWord = 32;
-            bitsPerBlock = 1;
-            offsetBlockInfoList = 512;
-            break;
-        case 0x04:
-            blocksPerWord = 16;
-            bitsPerBlock = 2;
-            offsetBlockInfoList = 1024;
-            break;
-        case 0x06:
-            blocksPerWord = 10;
-            bitsPerBlock = 3;
-            paddingFlag = true;
-            offsetBlockInfoList = 1640;
+            blockOffset = 1;
             break;
         case 0x08:
-            blocksPerWord = 8;
-            bitsPerBlock = 4;
-            offsetBlockInfoList = 2048;
+            // v8 - [version:byte][num_storages:byte][block storage1]...[blockStorageN]
+            v = cdata[2];
+            blockOffset = 3;
             break;
-        case 0x0a:
-            blocksPerWord = 6;
-            bitsPerBlock = 5;
-            paddingFlag = true;
-            offsetBlockInfoList = 2732;
-            break;
-        case 0x0c:
-            blocksPerWord = 5;
-            bitsPerBlock = 6;
-            paddingFlag = true;
-            offsetBlockInfoList = 3280;
-            break;
-        case 0x10:
-            blocksPerWord = 4;
-            bitsPerBlock = 8;
-            offsetBlockInfoList = (4096 / blocksPerWord) * 4;
-            break;
-        case 0x20:
-            blocksPerWord = 2;
-            bitsPerBlock = 16;
-            offsetBlockInfoList = (4096 / blocksPerWord) * 4;
+        case 0x09:
+            // v9 - [version:byte][num_storages:byte][sub_chunk_index:byte][block storage1]...[blockStorageN]
+            v = cdata[3];
+            blockOffset = 4;
             break;
         default:
-            log::error("Unknown chunk cdata[1] value = {}", v);
+            log::error("Invalid SubChunk version found ({})",
+                cdata[0]);
+            return -1;
+        }
+        
+        switch (v) {
+        case 0x1:
+        case 0x2:
+        case 0x3:
+        case 0x4:
+        case 0x5:
+        case 0x6:
+        case 0x8:
+        case 0x10:
+            bitsPerBlock = v >> 1;
+            blocksPerWord = floor(32 / bitsPerBlock);
+            wordCount = ceil(4096.0 / blocksPerWord);
+            paletteOffset = wordCount * 4 + blockOffset;
+            break;
+        default:
+            log::error("Unknown SubChunk palette value (value = {})", v);
             return -1;
         }
         return 0;
@@ -319,22 +304,24 @@ namespace mcpe_viz {
 
         // some details here: https://gist.github.com/Tomcc/a96af509e275b1af483b25c543cfbf37
 
+        // determine location of chunk palette
         int32_t blocksPerWord = -1;
         int32_t bitsPerBlock = -1;
-        bool paddingFlag = false;
-        int32_t offsetBlockInfoList = -1;
-        int32_t extraOffset = -1;
+        int32_t blockOffset = -1;
+        int32_t paletteOffset = -1;
 
         memset(emuchunk, 0, NUM_BYTES_CHUNK_V3 * sizeof(int16_t));
 
-        if (setupBlockVars_v7(cdata, blocksPerWord, bitsPerBlock, paddingFlag, offsetBlockInfoList, extraOffset) != 0) {
+        if (setupBlockVars_v7(cdata, blocksPerWord, bitsPerBlock, blockOffset, paletteOffset) !=
+            0) {
             return -1;
         }
 
         // read chunk palette and associate old-school block id's
         MyNbtTagList tagList;
-        int xoff = offsetBlockInfoList + 6 + extraOffset;
-        parseNbtQuiet(&cdata[xoff], int32_t(cdata_size) - xoff, cdata[offsetBlockInfoList + 3], tagList);
+        int xoff = paletteOffset + 4;
+
+        parseNbtQuiet(&cdata[xoff], int32_t(cdata_size - xoff), cdata[paletteOffset], tagList);
 
         std::vector<int32_t> chunkBlockPalette_BlockId(tagList.size());
         std::vector<int32_t> chunkBlockPalette_BlockData(tagList.size());
@@ -384,12 +371,12 @@ namespace mcpe_viz {
         for (int32_t cy = 0; cy < 16; cy++) {
             for (int32_t cx = 0; cx < 16; cx++) {
                 for (int32_t cz = 0; cz < 16; cz++) {
-                    paletteBlockId = getBlockId_LevelDB_v7(&cdata[2 + extraOffset], blocksPerWord, bitsPerBlock, cx, cz,
-                        cy);
+                    paletteBlockId = getBlockId_LevelDB_v7(&cdata[blockOffset],
+                        blocksPerWord, bitsPerBlock, cx, cz, cy);
 
                     // look up blockId
                     //todonow error checking
-                    if (paletteBlockId < chunkBlockPalette_BlockId.size()) {
+                    if (paletteBlockId <= chunkBlockPalette_BlockId.size()) {
                         blockId = chunkBlockPalette_BlockId[paletteBlockId];
                         blockData = chunkBlockPalette_BlockData[paletteBlockId];
                     }


### PR DESCRIPTION
Bedrock version 1.17.30 added sub-chunk version 9 which adds an
additional byte to the header information.

Simplify offset calculations to remove some hard coded values