### PR TITLE
remove broken options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Additional Features:
 * Create a powerful Google Maps-like web app viewer for your world.
   * Browse through all 256 layers of your world (Overworld and Nether) from bedrock to build limit.
   * Examine the location and details of mobs and items in your world.
-  * Show blocks where mobs can spawn.
   * Visualize chunk boundaries -- consider it an extremely cumbersome F3/debug mode!
   * Find slime chunks -- well, probably... slime chunk finding code is currently a bit weird in MCPE, it appears to work, but please be sure to confirm slimes are spawning in a chunk before you do a ton of work :)
   * Explore the biomes of your world.
@@ -33,9 +32,7 @@ Additional Features:
 * Create many types of images:
   * All layers of your world
   * Biomes in your world (very interesting!)
-  * Block light in your world (kind of like an image from space at night)
   * Block height in your world (kind of like a topographic map)
-  * Grass color in your world (it's neater than it sounds)
 
 * Create movies of all layers from bedrock to build limit (*ffmpeg* required)
 
@@ -113,8 +110,6 @@ Web App Usage Notes:
   * Show Mobs and Objects -- click on an entry and the map will be updated with labeled points.  You can toggle on as many different types as you like.  Click on the points or labels to get more info on the item.  Note that labels are not drawn when you are zoomed out.
   * Enable elevation overlay (shaded relief)
   * Enable chunk grid overlay
-
-You can visualize areas that are mob spawnable using the bedrock-viz command-line switch '--check-spawn'.  For example, '--check-spawn=0,-1,-152,180' will find all spawnable blocks in the overworld centered at -1,-152 with a radius of 180.  In the web app, you can toggle the "Spawnable" blocks on using the option on the "Blocks" menu.  The icons for the spawnable area are purple dots by default.  You can click on these dots to see the details.  You can then click on the "Pos" element to go to that layer (if you ran bedrock-viz with --html-all).  When you are viewing a raw layer (e.g. layer 12) as opposed to "Overview", the icons will change into green up arrows (indicating the spwanable block is above this layer), red down arrows (indicating the spawnable block is below this layer), or white squares (indicating the spawnable block is on this layer).  Keep in mind that the spawnable block is *above* the solid block the mob could spawn on.
 
 
 ## Web App Notes

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -24,18 +24,14 @@
 | `hide-top=did,bid`                             | Hide a block from top block (did=dimension id, bid=block id) |
 | `force-top=did,bid`                            | Force a block to top block (did=dimension id, bid=block id) |
 | `geojson-block=did,bid`                        | Add block to GeoJSON file for use in web app (did=dimension id, bid=block id) |
-| `check-spawn[able] did,x,z,dist`               | Add spawnable blocks to the geojson file (did=dimension id; checks a circle of radius 'dist' centered on x,z) |
 | `schematic[-get] did,x1,y1,z1,x2,y2,z2,fnpart` | Create a schematic file (fnpart) from (x1,y1,z1) to (x2,y2,z2) in dimension (did) |
 | `grid[=did]`                                   | Display chunk grid on top of images |
 | `all-image[=did]`                              | Create all image types |
 | `biome[=did]`                                  | Create a biome map image |
-| `grass[=did]`                                  | Create a grass color map image |
 | `height-col[=did]`                             | Create a height column map image (red is below sea; gray is sea; green is above sea) |
 | `height-col-gs[=did]`                          | Create a height column map image (grayscale) |
 | `height-col-alpha[=did]`                       | Create a height column map image (alpha) |
 | `shaded-relief[=did]`                          | Create a shaded relief image |
-| `blocklight[=did]`                             | Create a block light map image |
-| `skylight[=did]`                               | Create a sky light map image |
 | `slime-chunk[=did]`                            | Create a slime chunk map image |
 | `no-force-geojson`                             | Don't load geojson in html because we are going to use a web server (or Firefox) |
 | `shortrun`                                     | Debug testing parameter - process only first 1000 records |

--- a/include/control.h
+++ b/include/control.h
@@ -28,10 +28,7 @@ namespace mcpe_viz {
         std::string fnLayerHeight[kDimIdCount];
         std::string fnLayerHeightGrayscale[kDimIdCount];
         std::string fnLayerHeightAlpha[kDimIdCount];
-        std::string fnLayerBlockLight[kDimIdCount];
-        std::string fnLayerSkyLight[kDimIdCount];
         std::string fnLayerSlimeChunks[kDimIdCount];
-        std::string fnLayerGrass[kDimIdCount];
         std::string fnLayerShadedRelief[kDimIdCount];
         std::string fnLayerRaw[kDimIdCount][MAX_BLOCK_HEIGHT + 1];
 
@@ -42,12 +39,9 @@ namespace mcpe_viz {
 		int doHtml;
 		bool doTiles;
 		std::vector<int> doImageBiome;
-		std::vector<int> doImageGrass;
 		std::vector<int> doImageHeightCol;
 		std::vector<int> doImageHeightColGrayscale;
 		std::vector<int> doImageHeightColAlpha;
-		std::vector<int> doImageLightBlock;
-		std::vector<int> doImageLightSky;
 		std::vector<int> doImageSlimeChunks;
 		std::vector<int> doImageShadedRelief;
         bool autoTileFlag;
@@ -85,12 +79,9 @@ namespace mcpe_viz {
             doHtml = 0;
             doTiles = true;
             doImageBiome = kDimIdNone;
-            doImageGrass = kDimIdNone;
             doImageHeightCol = kDimIdNone;
             doImageHeightColGrayscale = kDimIdNone;
             doImageHeightColAlpha = kDimIdNone;
-            doImageLightBlock = kDimIdNone;
-            doImageLightSky = kDimIdNone;
             doImageSlimeChunks = kDimIdNone;
             doImageShadedRelief = kDimIdNone;
             noForceGeoJSONFlag = false;
@@ -118,11 +109,8 @@ namespace mcpe_viz {
                 fnLayerHeight[did] = "";
                 fnLayerHeightGrayscale[did] = "";
                 fnLayerHeightAlpha[did] = "";
-                fnLayerBlockLight[did] = "";
-                fnLayerSkyLight[did] = "";
                 fnLayerSlimeChunks[did] = "";
                 fnLayerShadedRelief[did] = "";
-                fnLayerGrass[did] = "";
                 for (int32_t i = 0; i <= MAX_BLOCK_HEIGHT; i++) {
                     fnLayerRaw[did][i] = "";
                 }

--- a/include/define.h
+++ b/include/define.h
@@ -46,6 +46,7 @@ namespace mcpe_viz {
     };
 
 	const std::vector<int> kDimIdAll{kDimIdOverworld, kDimIdNether, kDimIdTheEnd};
+    const std::vector<int> kDimJustOverworld{kDimIdOverworld};
     const std::vector<std::string> kDimIdAllStrings {"0","1","2"};
     const std::string kDimIdAllStr = "0 1 2";
     const std::vector<std::string> kDimIdNames {"overworld","nether","the-end"};

--- a/src/args.cc
+++ b/src/args.cc
@@ -45,8 +45,6 @@ Extended Options:
     --force-top=did,bid      Force a block to top block (did=dimension id, bid=block id)
     --geojson-block=did,bid  Add block to GeoJSON file for use in web app (did=dimension id, bid=block id)
 
-    --check-spawn[able] did,x,z,dist
-                             Add spawnable blocks to the geojson file (did=dimension id; checks a circle of radius 'dist' centered on x,z)
     --schematic[-get] did,x1,y1,z1,x2,y2,z2,fnpart
                              Create a schematic file (fnpart) from (x1,y1,z1) to (x2,y2,z2) in dimension (did)
     Note: [=did] are optional dimension-ids - if not specified, do all dimensions 
@@ -55,13 +53,10 @@ Extended Options:
     --grid[=did]             Display chunk grid on top of images
     --all-image[=did]        Create all image types
     --biome[=did]            Create a biome map image
-    --grass[=did]            Create a grass color map image
     --height-col[=did]       Create a height column map image (red is below sea; gray is sea; green is above sea)
     --height-col-gs[=did]    Create a height column map image (grayscale)
     --height-col-alpha[=did] Create a height column map image (alpha)
     --shaded-relief[=did]    Create a shaded relief image
-    --blocklight[=did]       Create a block light map image
-    --skylight[=did]         Create a sky light map image
     --slime-chunk[=did]      Create a slime chunk map image
 
     --no-force-geojson       Don't load geojson in html because we are going to use a web server (or Firefox)

--- a/src/world/dimension_data.cc
+++ b/src/world/dimension_data.cc
@@ -1208,11 +1208,6 @@ namespace mcpe_viz {
             control.fnLayerBiome[dimId] = std::string(dirOut + "/" + fnBase + "." + name + ".biome.png");
             generateImage(control.fnLayerBiome[dimId], kImageModeBiome);
         }
-        if (checkDoForDim(control.doImageGrass)) {
-            log::info("  Generate Grass Image");
-            control.fnLayerGrass[dimId] = std::string(dirOut + "/" + fnBase + "." + name + ".grass.png");
-            generateImage(control.fnLayerGrass[dimId], kImageModeGrass);
-        }
         if (checkDoForDim(control.doImageHeightCol)) {
             log::info("  Generate Height Column Image");
             control.fnLayerHeight[dimId] = std::string(dirOut + "/" + fnBase + "." + name + ".height_col.png");
@@ -1229,16 +1224,6 @@ namespace mcpe_viz {
             control.fnLayerHeightAlpha[dimId] = std::string(
                 dirOut + "/" + fnBase + "." + name + ".height_col_alpha.png");
             generateImage(control.fnLayerHeightAlpha[dimId], kImageModeHeightColAlpha);
-        }
-        if (checkDoForDim(control.doImageLightBlock)) {
-            log::info("  Generate Block Light Image");
-            control.fnLayerBlockLight[dimId] = std::string(dirOut + "/" + fnBase + "." + name + ".light_block.png");
-            generateImage(control.fnLayerBlockLight[dimId], kImageModeBlockLight);
-        }
-        if (checkDoForDim(control.doImageLightSky)) {
-            log::info("  Generate Sky Light Image");
-            control.fnLayerSkyLight[dimId] = std::string(dirOut + "/" + fnBase + "." + name + ".light_sky.png");
-            generateImage(control.fnLayerSkyLight[dimId], kImageModeSkyLight);
         }
         if (checkDoForDim(control.doImageSlimeChunks)) {
             log::info("  Generate Slime Chunks Image");

--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -886,10 +886,7 @@ namespace mcpe_viz
             doOutput_Tile_image(control.fnLayerHeight[dimid]);
             doOutput_Tile_image(control.fnLayerHeightGrayscale[dimid]);
             doOutput_Tile_image(control.fnLayerHeightAlpha[dimid]);
-            doOutput_Tile_image(control.fnLayerBlockLight[dimid]);
-            doOutput_Tile_image(control.fnLayerSkyLight[dimid]);
             doOutput_Tile_image(control.fnLayerSlimeChunks[dimid]);
-            doOutput_Tile_image(control.fnLayerGrass[dimid]);
             doOutput_Tile_image(control.fnLayerShadedRelief[dimid]);
             for (int32_t cy = 0; cy <= MAX_BLOCK_HEIGHT; cy++) {
                 if (cy % 32 == 0) {
@@ -1051,9 +1048,7 @@ namespace mcpe_viz
                 fprintf(fp, "  fnLayerHeightAlpha: '%s',\n", makeTileURL(control.fnLayerHeightAlpha[did]).c_str());
                 fprintf(fp, "  fnLayerShadedRelief: '%s',\n",
                     makeTileURL(control.fnLayerShadedRelief[did]).c_str());
-                fprintf(fp, "  fnLayerBlockLight: '%s',\n", makeTileURL(control.fnLayerBlockLight[did]).c_str());
                 fprintf(fp, "  fnLayerSlimeChunks: '%s',\n", makeTileURL(control.fnLayerSlimeChunks[did]).c_str());
-                fprintf(fp, "  fnLayerGrass: '%s',\n", makeTileURL(control.fnLayerGrass[did]).c_str());
 
                 fprintf(fp, "  listLayers: [\n");
                 for (int32_t i = 0; i <= MAX_BLOCK_HEIGHT; i++) {

--- a/static/bedrock_viz.html.template
+++ b/static/bedrock_viz.html.template
@@ -89,8 +89,6 @@
 	    <li><a href="#" class="imageSelect" data-id="1">Biome</a></li>
 	    <li><a href="#" class="imageSelect" data-id="2">Height</a></li>
 	    <li><a href="#" class="imageSelect" data-id="3">Height (Grayscale)</a></li>
-	    <li><a href="#" class="imageSelect" data-id="4">Block Light</a></li>
-	    <li><a href="#" class="imageSelect" data-id="5">Grass Color</a></li>
 	  </ul>
 	</div>
 	

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -2012,16 +2012,6 @@ function setLayerById(id) {
             globalLayerMode = 0; globalLayerId = 3;
             $('#imageSelectName').html('Height (Grayscale)');
         }
-    } else if (id === 4) {
-        if (setLayer(dimensionInfo[globalDimensionId].fnLayerBlockLight, extraHelp) === 0) {
-            globalLayerMode = 0; globalLayerId = 4;
-            $('#imageSelectName').html('Block Light');
-        }
-    } else if (id === 5) {
-        if (setLayer(dimensionInfo[globalDimensionId].fnLayerGrass, extraHelp) === 0) {
-            globalLayerMode = 0; globalLayerId = 5;
-            $('#imageSelectName').html('Grass Color');
-        }
     } else {
         // default is overview map
         if (setLayer(dimensionInfo[globalDimensionId].fnLayerTop, '') === 0) {
@@ -2743,8 +2733,6 @@ function doTour(aboutFlag) {
                     '<li><b>Biome</b> is an image of the biomes in your world.</li>' +
                     '<li><b>Height</b> is an image of the heights of the highest blocks in your world.  Red is below sea level, Green is above.</li>' +
                     '<li><b>Height (Grayscale)</b> is an image of the heights of the highest blocks in your world in grayscale.</li>' +
-                    '<li><b>Block Light</b> is an image of the block light levels of the highest blocks in your world.</li>' +
-                    '<li><b>Grass Color</b> is an image of the color of grass in all parts of your world.</li>' +
                     '</ul>'
             },
             {


### PR DESCRIPTION
There are currently 4 things that bedrock_viz claims to be able to generate that are broken and there is not a clean path forward for fixing them (so far as I know). This PR removes the user facing docs and options to activate them, and removes one call from the main application that does the checking for spawnable blocks.

I've left as much of the heavy lifting for the actual checking in place as possible.

Also default slime chunk checking to overworld layer only for the two html options that automatically enable it... not much point to doing the work for the other dimensions.