### PR TITLE
setup each dimension to have dynamic top/bottom Y values

### DIFF
--- a/include/control.h
+++ b/include/control.h
@@ -44,6 +44,8 @@ namespace mcpe_viz {
 		std::vector<int> doImageHeightColAlpha;
 		std::vector<int> doImageSlimeChunks;
 		std::vector<int> doImageShadedRelief;
+        int dimYBottom[kDimIdCount];
+        int dimYTop[kDimIdCount];
         bool autoTileFlag;
         bool noForceGeoJSONFlag;
         bool shortRunFlag;
@@ -103,6 +105,17 @@ namespace mcpe_viz {
             // todo - cmdline option for this?
             heightMode = kHeightModeTop;
 
+            // default top/bottom Y levels
+            // Overworld
+            dimYBottom[kDimIdOverworld] = -64;
+            dimYTop[kDimIdOverworld] = 319;
+            // Nether
+            dimYBottom[kDimIdNether] = 0;
+            dimYTop[kDimIdNether] = 127;
+            // The End
+            dimYBottom[kDimIdTheEnd] = 0;
+            dimYTop[kDimIdTheEnd] = 127;
+
             for (int32_t did = 0; did < kDimIdCount; did++) {
                 fnLayerTop[did] = "";
                 fnLayerBiome[did] = "";
@@ -111,8 +124,8 @@ namespace mcpe_viz {
                 fnLayerHeightAlpha[did] = "";
                 fnLayerSlimeChunks[did] = "";
                 fnLayerShadedRelief[did] = "";
-                for (int32_t i = 0; i <= MAX_BLOCK_HEIGHT; i++) {
-                    fnLayerRaw[did][i] = "";
+                for (int32_t i = dimYBottom[did]; i <= dimYTop[did]; i++) {
+                    fnLayerRaw[did][i - dimYBottom[did]] = "";
                 }
             }
         }

--- a/include/define.h
+++ b/include/define.h
@@ -4,12 +4,23 @@
 #include <string>
 
 namespace mcpe_viz {
-    // maximum build height -- as of MCPE 0.13 it is 127
+    // absolutely block limits. Note that every dimension has unique dynamic
+    // limits in control.dimYBottom and control.dimYTop, which should generally
+    // be what is used for loops. These are still useful for allocation of
+    // worst case scenarios, but should generally not be used if you know what
+    // dimension you are working with.
     const int32_t MAX_BLOCK_HEIGHT_127 = 127;
     const int32_t MAX_BLOCK_HEIGHT = 319;
     const int32_t MIN_BLOCK_HEIGHT = -64;
 
+    /**
+     * @deprecated - need to calculate these by dimension, and adjust for zero indexing
+     * @see generateSlices::worldCubicY for example of how to do it. (the code just above it actually)
+     */
     const int32_t MIN_CUBIC_Y = MIN_BLOCK_HEIGHT / 16;
+    /**
+     * @deprecated
+     */
     const int32_t MAX_CUBIC_Y = (MAX_BLOCK_HEIGHT + 1) / 16;
 
     const int32_t NUM_BYTES_CHUNK_V3 = 10241;

--- a/src/world/dimension_data.cc
+++ b/src/world/dimension_data.cc
@@ -652,15 +652,7 @@ namespace mcpe_viz {
                     int32_t cubicFoundCount = 0;
                     int32_t dimMinCubicY = dimensionBottomY / 16;
                     int32_t dimMaxCubicY = dimensionTopY / 16;
-                    // the above cubics are the in world Y values, eg -4..20
-                    // the below cubics are the in leveldb Y values, eg 0..24
-                    // NOTE: I'm assuming other dimensions with negative Y values will zero index like overworld does.
-                    // for now, since they have 0 for minimum Y it's a no-op.
-                    int32_t dbMinCubicY = 0;
-                    int32_t dbMaxCubicY = dimMaxCubicY - dimMinCubicY;
-                    for (int8_t cubicy = dbMinCubicY; cubicy <= dbMaxCubicY; cubicy++) {
-                        // so we iterrate on the LEVEL DB's Y, but then adjust it to get the WORLD Y
-                        int8_t worldCubicY = cubicy + dimMinCubicY;
+                    for (int32_t cubicY = dimMinCubicY; cubicY <= dimMaxCubicY; cubicY++) {
                         // todobug - this fails around level 112? on another1 -- weird -- run a valgrind to see where we're messing up
                         //check valgrind output
 
@@ -670,7 +662,7 @@ namespace mcpe_viz {
                             memcpy(&keybuf[0], &chunkX, sizeof(int32_t));
                             memcpy(&keybuf[4], &chunkZ, sizeof(int32_t));
                             memcpy(&keybuf[8], &kt_v3, sizeof(uint8_t));
-                            memcpy(&keybuf[9], &cubicy, sizeof(uint8_t));
+                            memcpy(&keybuf[9], &cubicY, sizeof(uint8_t));
                             keybuflen = 10;
                         }
                         else {
@@ -679,7 +671,7 @@ namespace mcpe_viz {
                             memcpy(&keybuf[4], &chunkZ, sizeof(int32_t));
                             memcpy(&keybuf[8], &kw, sizeof(int32_t));
                             memcpy(&keybuf[12], &kt_v3, sizeof(uint8_t));
-                            memcpy(&keybuf[13], &cubicy, sizeof(uint8_t));
+                            memcpy(&keybuf[13], &cubicY, sizeof(uint8_t));
                             keybuflen = 14;
                         }
 
@@ -722,7 +714,7 @@ namespace mcpe_viz {
                                 for (int32_t cz = 0; cz < 16; cz++) {
                                     currTopBlockY = tbuf[(imageZ + cz) * imageW + imageX + cx];
                                     for (int32_t ccy = 0; ccy < 16; ccy++) {
-                                        int32_t cy = worldCubicY * 16 + ccy;
+                                        int32_t cy = cubicY * 16 + ccy;
 
                                         // todo - if we use this, we get blockdata errors... somethings not right
                                         if (wordModeFlag) {
@@ -815,7 +807,7 @@ namespace mcpe_viz {
                                 for (int32_t cz = 0; cz < 16; cz++) {
                                     currTopBlockY = tbuf[(imageZ + cz) * imageW + imageX + cx];
                                     for (int32_t ccy = 0; ccy < 16; ccy++) {
-                                        int32_t cy = worldCubicY * 16 + ccy;
+                                        int32_t cy = cubicY * 16 + ccy;
                                         if ((cy > currTopBlockY) && (dimId != kDimIdNether)) {
                                             // special handling for air -- keep existing value if we are above top block
                                             // the idea is to show air underground, but hide it above so that the map is not all black pixels @ y=MAX_BLOCK_HEIGHT

--- a/src/world/dimension_data.cc
+++ b/src/world/dimension_data.cc
@@ -479,7 +479,7 @@ namespace mcpe_viz {
         // create png helpers
         int dimensionBottomY = control.dimYBottom[dimId];
         int dimensionTopY = control.dimYTop[dimId];
-        PngWriter png[(dimensionTopY - dimensionBottomY) + 1];
+        PngWriter* png = new PngWriter[(dimensionTopY - dimensionBottomY + 1)];
         for (int32_t cy = dimensionBottomY; cy <= dimensionTopY; cy++) {
             std::string fnameTmp = fnBase + ".slice.full.";
             fnameTmp += name;
@@ -497,7 +497,7 @@ namespace mcpe_viz {
         }
 
         // create row buffers
-        uint8_t* rbuf[(dimensionTopY - dimensionBottomY) + 1];
+        uint8_t** rbuf = new uint8_t*[(dimensionTopY - dimensionBottomY) + 1];
         for (int32_t cy = dimensionBottomY; cy <= dimensionTopY; cy++) {
             rbuf[cy - dimensionBottomY] = new uint8_t[(imageW * 3) * 16];
             // setup row pointers
@@ -865,10 +865,10 @@ namespace mcpe_viz {
         }
 
         delete[] tbuf;
-
-        // slogger.msg(kLogInfo1,"    Chunk Info: Found = %d / Not Found (our list) = %d / Not Found (leveldb) = %d\n", foundCt, notFoundCt1, notFoundCt2);
-
+        delete[] rbuf;
+        delete[] png;
         delete[] emuchunk;
+
         return 0;
     }
 

--- a/src/world/dimension_data.cc
+++ b/src/world/dimension_data.cc
@@ -651,7 +651,7 @@ namespace mcpe_viz {
                     // we need to iterate over all possible y cubic chunks here...
                     int32_t cubicFoundCount = 0;
                     int32_t dimMinCubicY = dimensionBottomY / 16;
-                    int32_t dimMaxCubicY = dimensionTopY / 16;
+                    int32_t dimMaxCubicY = dimensionTopY + 1 / 16;
                     // the above cubics are the in world Y values, eg -4..20
                     // the below cubics are the in leveldb Y values, eg 0..24
                     // NOTE: I'm assuming other dimensions with negative Y values will zero index like overworld does.

--- a/src/world/dimension_data.cc
+++ b/src/world/dimension_data.cc
@@ -852,14 +852,16 @@ namespace mcpe_viz {
 
             // put the png rows
             // todo - png lib is SLOW - worth it to alloc a larger window (16-row increments) and write in batches?
-            for (int32_t cy = dimensionBottomY; cy <= dimensionTopY; cy++) {
-                png_write_rows(png[cy - dimensionBottomY].png, png[cy - dimensionBottomY].row_pointers, 16);
+            // y here is already shifted by dimensionBottomY so we don't have to subtract it every loop
+            for (int32_t y = 0; y <= dimensionTopY - dimensionBottomY; y++) {
+                png_write_rows(png[y].png, png[y].row_pointers, 16);
             }
         }
 
-        for (int32_t cy = dimensionBottomY; cy <= dimensionTopY; cy++) {
-            delete[] rbuf[cy - dimensionBottomY];
-            png[cy - dimensionBottomY].close();
+        // y here is already shifted by dimensionBottomY so we don't have to subtract it every loop
+        for (int32_t y = 0; y <= dimensionTopY - dimensionBottomY; y++) {
+            delete[] rbuf[y];
+            png[y].close();
         }
 
         delete[] tbuf;

--- a/src/world/dimension_data.cc
+++ b/src/world/dimension_data.cc
@@ -651,14 +651,14 @@ namespace mcpe_viz {
                     // we need to iterate over all possible y cubic chunks here...
                     int32_t cubicFoundCount = 0;
                     int32_t dimMinCubicY = dimensionBottomY / 16;
-                    int32_t dimMaxCubicY = dimensionTopY + 1 / 16;
+                    int32_t dimMaxCubicY = dimensionTopY / 16;
                     // the above cubics are the in world Y values, eg -4..20
                     // the below cubics are the in leveldb Y values, eg 0..24
                     // NOTE: I'm assuming other dimensions with negative Y values will zero index like overworld does.
                     // for now, since they have 0 for minimum Y it's a no-op.
                     int32_t dbMinCubicY = 0;
                     int32_t dbMaxCubicY = dimMaxCubicY - dimMinCubicY;
-                    for (int8_t cubicy = dbMinCubicY; cubicy < dbMaxCubicY; cubicy++) {
+                    for (int8_t cubicy = dbMinCubicY; cubicy <= dbMaxCubicY; cubicy++) {
                         // so we iterrate on the LEVEL DB's Y, but then adjust it to get the WORLD Y
                         int8_t worldCubicY = cubicy + dimMinCubicY;
                         // todobug - this fails around level 112? on another1 -- weird -- run a valgrind to see where we're messing up

--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -888,11 +888,13 @@ namespace mcpe_viz
             doOutput_Tile_image(control.fnLayerHeightAlpha[dimid]);
             doOutput_Tile_image(control.fnLayerSlimeChunks[dimid]);
             doOutput_Tile_image(control.fnLayerShadedRelief[dimid]);
-            for (int32_t cy = MIN_BLOCK_HEIGHT; cy <= MAX_BLOCK_HEIGHT; cy++) {
+            int dimensionBottomY = control.dimYBottom[dimid];
+            int dimensionTopY = control.dimYTop[dimid];
+            for (int32_t cy = dimensionBottomY; cy <= dimensionTopY; cy++) {
                 if (cy % 32 == 0) {
-                    log::info("  Layer {} of {}", cy, MAX_BLOCK_HEIGHT);
+                    log::info("  Layer {} in {}..{}", cy, dimensionBottomY, dimensionTopY);
                 }
-                doOutput_Tile_image(control.fnLayerRaw[dimid][cy - MIN_BLOCK_HEIGHT]);
+                doOutput_Tile_image(control.fnLayerRaw[dimid][cy - dimensionBottomY]);
             }
         }
 
@@ -1050,9 +1052,14 @@ namespace mcpe_viz
                     makeTileURL(control.fnLayerShadedRelief[did]).c_str());
                 fprintf(fp, "  fnLayerSlimeChunks: '%s',\n", makeTileURL(control.fnLayerSlimeChunks[did]).c_str());
 
+                int dimensionBottomY = control.dimYBottom[did];
+                int dimensionTopY = control.dimYTop[did];
+
+                fprintf(fp, "  bottomLayer: %d,\n", dimensionBottomY);
+                fprintf(fp, "  topLayer: %d,\n", dimensionTopY);
                 fprintf(fp, "  listLayers: [\n");
-                for (int32_t i = MIN_BLOCK_HEIGHT; i <= MAX_BLOCK_HEIGHT; i++) {
-                    fprintf(fp, "    '%s',\n", makeTileURL(control.fnLayerRaw[did][i - MIN_BLOCK_HEIGHT]).c_str());
+                for (int32_t y = dimensionBottomY; y <= dimensionTopY; y++) {
+                    fprintf(fp, "    '%s',\n", makeTileURL(control.fnLayerRaw[did][y - dimensionBottomY]).c_str());
                 }
                 fprintf(fp, "  ]\n");
                 if ((did + 1) < kDimIdCount) {

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -2600,8 +2600,8 @@ function layerGoto(layer) {
     var max = dimensionInfo[globalDimensionId].topLayer;
 
     // bound the layer within the dimensions limits
-    if (layerRawIndex < min) { layerRawIndex = min; }
-    if (layerRawIndex > max) { layerRawIndex = max; }
+    if (layer < min) { layer = min; }
+    if (layer > max) { layer = max; }
     // offset into the list by the min, to map -64 to 0 for overworld
     if (setLayer(dimensionInfo[globalDimensionId].listLayers[layer - min], 'You need to run bedrock_viz with --html-all') === 0) {
         globalLayerMode = 1;

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -2213,15 +2213,20 @@ function setDimensionById(id) {
     else if (id === 1) {
         globalDimensionId = id;
         $('#dimensionSelectName').html('Nether');
+        adjustLayerDropDown(0, 128);
+        $('.layerGoto[data-id="62"]').hide();
     }
     else if (id === 2) {
         globalDimensionId = id;
         $('#dimensionSelectName').html('The End');
+        adjustLayerDropDown(0, 128);
+        $('.layerGoto[data-id="62"]').hide();
     }
     else {
         // default to overworld
         globalDimensionId = id;
         $('#dimensionSelectName').html('Overworld');
+        adjustLayerDropDown(-64, 319);
     }
 
     if (prevDimId !== globalDimensionId) {
@@ -2229,6 +2234,16 @@ function setDimensionById(id) {
     }
 }
 
+function adjustLayerDropDown(min, max) {
+    var lcv = -64
+    for(; lcv <= 319; lcv++) {
+        if (lcv < min || lcv > max) {
+            $('.layerGoto[data-id="' + lcv + '"]').hide();
+        } else {
+            $('.layerGoto[data-id="' + lcv + '"]').show();
+        }
+    }
+}
 
 function checkPlayerDistance(feature) {
     if ( ! doCheckPlayerDistanceFlag ) { return true; }
@@ -2569,17 +2584,26 @@ function spawnableToggle() {
 function layerMove(delta) {
     //this_.getMap().getView().setRotation(0);
     layerRawIndex += delta;
-    if (layerRawIndex < -64) { layerRawIndex = -64; }
-    if (layerRawIndex > 319) { layerRawIndex = 319; }
+    var min = dimensionInfo[globalDimensionId].bottomLayer;
+    var max = dimensionInfo[globalDimensionId].topLayer;
+
+    // bound the layer within the dimensions limits
+    if (layerRawIndex < min) { layerRawIndex = min; }
+    if (layerRawIndex > max) { layerRawIndex = max; }
     layerGoto(layerRawIndex);
 }
 
 function layerGoto(layer) {
     // we make sure that layer is an integer (mob positions can have decimal points)
     layer = Math.floor(layer);
-    if (layer < -64) { layer = -64; }
-    if (layer > 319) { layer = 319; }
-    if (setLayer(dimensionInfo[globalDimensionId].listLayers[layer + 64], 'You need to run bedrock_viz with --html-all') === 0) {
+    var min = dimensionInfo[globalDimensionId].bottomLayer;
+    var max = dimensionInfo[globalDimensionId].topLayer;
+
+    // bound the layer within the dimensions limits
+    if (layerRawIndex < min) { layerRawIndex = min; }
+    if (layerRawIndex > max) { layerRawIndex = max; }
+    // offset into the list by the min, to map -64 to 0 for overworld
+    if (setLayer(dimensionInfo[globalDimensionId].listLayers[layer - min], 'You need to run bedrock_viz with --html-all') === 0) {
         globalLayerMode = 1;
         layerRawIndex = layer;
         $('#layerNumber').html('' + layer);


### PR DESCRIPTION
This builds atop the work down by @geoffholden to make it more efficient (not trying to render everything from -64 to 319 for nether and end) and correct an issue I noticed trying to use it (-64 was at 0 on the final map?)

I'm not 100% certain on the zero indexed y cubics for *all* post 0.17 chunks... but I don't see any indication of how we would *know*.... I suspect this will create an issue with reading older block formats, and I intend to look at some of my older backups, but I wanted to get this change out for visibility while I (and hopefully others) try it against various worlds.