### PR TITLE
Adding TileEntity support for Item Frames.

### DIFF
--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -2156,9 +2156,18 @@ namespace mcpe_viz
                     // todo - has a LIST of items in the cauldron?; PotionId; SplashPotion
                 }
                 else if (tileEntity->id == "ItemFrame") {
-                    // todo - new for 0.14
-                    // todo - anything interesting?
-                    // todo - Item; ItemDropChance; ItemRotation
+                    // todo - ItemRotation
+                    if (tc.has_key("Item", nbt::tag_type::Compound)) {
+                        tileEntity->containerFlag = true;
+                    }
+                    parseFlag = true;
+                }
+                else if (tileEntity->id == "GlowItemFrame") {
+                    // todo - ItemRotation
+                    if (tc.has_key("Item", nbt::tag_type::Compound)) {
+                        tileEntity->containerFlag = true;
+                    }
+                    parseFlag = true;
                 }
                 else if (tileEntity->id == "Comparator") {
                     // todo - new for 0.14
@@ -2202,10 +2211,15 @@ namespace mcpe_viz
                 }
 
                 if (tileEntity->containerFlag) {
-                    nbt::tag_list items = tc["Items"].as<nbt::tag_list>();
-                    for (const auto& iter : items) {
-                        nbt::tag_compound iitem = iter.as<nbt::tag_compound>();
-                        tileEntity->addItem(iitem);
+                    if (tc.has_key("Items", nbt::tag_type::List)) {
+                        nbt::tag_list items = tc["Items"].as<nbt::tag_list>();
+                        for (const auto& iter : items) {
+                            nbt::tag_compound iitem = iter.as<nbt::tag_compound>();
+                            tileEntity->addItem(iitem);
+                        }
+                    } else if (tc.has_key("Item", nbt::tag_type::Compound)) {
+                       nbt::tag_compound item = tc["Item"].as<nbt::tag_compound>();
+                       tileEntity->addItem(item);
                     }
                 }
 

--- a/static/bedrock_viz.html.template
+++ b/static/bedrock_viz.html.template
@@ -211,6 +211,8 @@
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="NetherPortal">Nether Portal</a></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="SignNonBlank">Sign (Non-blank)</a></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="SignBlank">Sign (Blank)</a></li>
+	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="ItemFrame">Item Frame</a></li>
+	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="GlowItemFrame">Glow Item Frame</a></li>
 	    <li role="separator" class="divider"></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="Chest">Chest</a></li>
 	    <li><a href="#" class="tileEntityToggle" data-type="O" data-id="Barrel">Barrel</a></li>


### PR DESCRIPTION
This adds parsing of the item stored in item frames (and glow item frames), and display in the UI.
Updated the logic on ParsedTileEntity's container flag so that it can parse entities with a single item as well as a list of items. 