### PR TITLE
Adds support for the new actor storage in 1.18.30

### DIFF
--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -1706,6 +1706,11 @@ namespace mcpe_viz
 
                 // todo - other interesting bits?
 
+                if (tc.has_key("LastDimensionId", nbt::tag_type::Int)) {
+                    entity->dimensionId = tc["LastDimensionId"].as<nbt::tag_int>().get();
+                    actualDimensionId = entity->dimensionId;
+                }
+
                 if (tc.has_key("ItemInHand", nbt::tag_type::Compound)) {
                     entity->doItemInHand(tc["ItemInHand"].as<nbt::tag_compound>());
                 }

--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -894,6 +894,7 @@ namespace mcpe_viz
                 parseNbt_entity(kDimIdOverworld, "actor", actor_tags, false, false, "", "");
             }
         }
+        actorIds.clear();
 
         for (auto vid : villages) {
             std::string data;


### PR DESCRIPTION
Details about the new storage can be found here: https://docs.microsoft.com/en-us/minecraft/creator/documents/actorstorage

In short, entity data isn't stored in the chunk data anymore. There's an entry per chunk that has a list of Actor IDs, and then there are separate entries for each actor.

Fixes #160 