### PR TITLE
Basic support for 3D biome data

### DIFF
--- a/include/world/chunk_data.h
+++ b/include/world/chunk_data.h
@@ -63,6 +63,8 @@ namespace mcpe_viz {
 
         int32_t _do_chunk_biome_v3(int32_t tchunkX, int32_t tchunkZ, const char* cdata, int32_t cdatalen);
 
+        int32_t _do_chunk_biome_3d(int32_t tchunkX, int32_t tchunkZ, const char* cdata, size_t cdatalen);
+
         int32_t checkSpawnable(leveldb::DB* db, int32_t dimId, const CheckSpawnList& listCheckSpawn);
     };
 

--- a/include/world/dimension_data.h
+++ b/include/world/dimension_data.h
@@ -176,13 +176,27 @@ namespace mcpe_viz {
             case 3:
                 // 0.17 and later?
                 // we need to process all sub-chunks, not just blindy add them
+                {
 
-                ChunkKey chunkKey(chunkX, chunkZ);
-                if (!chunks_has_key(chunks, chunkKey)) {
-                    chunks[chunkKey] = std::unique_ptr<ChunkData_LevelDB>(new ChunkData_LevelDB());
+                    ChunkKey chunkKey(chunkX, chunkZ);
+                    if (!chunks_has_key(chunks, chunkKey)) {
+                        chunks[chunkKey] = std::unique_ptr<ChunkData_LevelDB>(new ChunkData_LevelDB());
+                    }
+
+                    return chunks[chunkKey]->_do_chunk_biome_v3(chunkX, chunkZ, cdata, cdatalen);
                 }
+                break;
+            case 4:
+                // 1.18
+                {
+                    ChunkKey chunkKey(chunkX, chunkZ);
+                    if (!chunks_has_key(chunks, chunkKey)) {
+                        chunks[chunkKey] = std::unique_ptr<ChunkData_LevelDB>(new ChunkData_LevelDB());
+                    }
+                    return chunks[chunkKey]->_do_chunk_biome_3d(chunkX, chunkZ, cdata, cdatalen);
+                }
+                break;
 
-                return chunks[chunkKey]->_do_chunk_biome_v3(chunkX, chunkZ, cdata, cdatalen);
             }
             log::error("Unknown chunk format ({})", tchunkFormatVersion);
             return -1;

--- a/include/world/misc.h
+++ b/include/world/misc.h
@@ -23,6 +23,7 @@ namespace mcpe_viz {
 //        getBlockId_LevelDB_v7(const char* p, int blocksPerWord, int bitsPerBlock, int32_t x, int32_t z, int32_t y);
     uint8_t getColData_Height_LevelDB_v3(const char* buf, int32_t x, int32_t z);
     uint32_t getColData_GrassAndBiome_LevelDB_v3(const char* buf, int32_t buflen, int32_t x, int32_t z);
+    uint32_t getColData_Biome_LevelDB_3d(const char* buf, int32_t buflen, int32_t x, int32_t z);
     int32_t _calcOffsetBlock_LevelDB_v3_fullchunk(int32_t x, int32_t z, int32_t y);
     uint8_t getData_LevelDB_v3_fullchunk(const char* p, int32_t x, int32_t z, int32_t y);
 

--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -807,6 +807,7 @@ namespace mcpe_viz
                 {
                     dimDataList[chunkDimId]->addChunkColumnData(4, chunkX, chunkZ, cdata, int32_t(cdata_size));
                 }
+                break;
 
 
                 /*

--- a/src/world/world.cc
+++ b/src/world/world.cc
@@ -794,6 +794,20 @@ namespace mcpe_viz
                 }
                 break;
 
+                case 0x2b:
+                    // 1.18 3D biome data
+                    // 512 bytes -> heightmap
+                    // Paletted biome data per subcunk (16x16x16) from bottom up
+                    //   1 byte header - 0xff means non-existant
+                    //     bit 0 - always 1?
+                    //     bits 7..1: bits per value for array (can be 0)
+                    //   n byte array (n = 4096/8 * bits per value)
+                    //   int32 palette length
+                    //   palette entries (int32)
+                {
+                    dimDataList[chunkDimId]->addChunkColumnData(4, chunkX, chunkZ, cdata, int32_t(cdata_size));
+                }
+
 
                 /*
    todohere todonow

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -1983,6 +1983,9 @@ function setLayer(fn, extraHelp) {
         disableLayerSmoothing(layerMain);
     } else {
         layerMain.setSource(srcLayerMain);
+        if ( useTilesFlag ) {
+          layerMain.setExtent(extent);
+        }
     }
 
     if ( vectorPoints ) {


### PR DESCRIPTION
Biome data is now stored per block in a new 0x2B record.
This adds a basic parser for that data, but only keeps the data for the topmost block.
This will only partially address #172, as we'll only show the surface biome, but we'll no longer be showing uninitialized memory as the biome view for these new chunks.