### PR TITLE
Added stubs for missing tileEntities

### DIFF
--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -2210,7 +2210,39 @@ namespace mcpe_viz
                         parseFlag = true;
                     }
                 }
-
+                else if (tileEntity->id == "Beehive") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "Bell") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "BlastFurnace") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "BrushableBlock") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "Campfire") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "Lectern") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "SculkCatalyst") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "SculkSensor") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "SculkShrieker") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "Smoker") {
+                    // todo - anything interesting?
+		}
+		else if (tileEntity->id == "SporeBlossom") {
+                    // todo - anything interesting?
+		}
                 else {
                     log::debug("Unknown tileEntity id=({})", tileEntity->id);
                 }

--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -2241,8 +2241,9 @@ namespace mcpe_viz
 		else if (tileEntity->id == "BrushableBlock") {
                     // todo - anything interesting?
 		    // LootTable
-		    //     loot_tables/entities/warm_ocean_ruins_brushable_block.json
+		    //     loot_tables/entities/cold_ocean_ruins_brushable_block.json
 		    //     loot_tables/entities/desert_pyramid_brushable_block.json
+		    //     loot_tables/entities/desert_well_brushable_block.json
 		    //     loot_tables/entities/trail_ruins_brushable_block_common.json
 		    //     loot_tables/entities/trail_ruins_brushable_block_rare.json
 		    //     loot_tables/entities/warm_ocean_ruins_brushable_block.json

--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -2105,6 +2105,14 @@ namespace mcpe_viz
                 }
                 else if (tileEntity->id == "Furnace") {
                     // todo - anything interesting?
+		    // BurnDuration
+		    // BurnTime
+		    // CookTime
+		    // Items
+		    //     Slot 0 - Input
+		    //     Slot 1 - Fuel
+		    //     Slot 2 - Output
+		    // StoredXPInt
                 }
                 else if (tileEntity->id == "MobSpawner") {
                     tileEntity->addMobSpawner(tc);
@@ -2215,15 +2223,42 @@ namespace mcpe_viz
 		}
 		else if (tileEntity->id == "Bell") {
                     // todo - anything interesting?
+		    // Direction
+		    // Ringing
+		    // Ticks
 		}
 		else if (tileEntity->id == "BlastFurnace") {
                     // todo - anything interesting?
+		    // BurnDuration
+		    // BurnTime
+		    // CookTime
+		    // Items
+		    //     Slot 0 - Input
+		    //     Slot 1 - Fuel
+		    //     Slot 2 - Output
+		    // StoredXPInt
 		}
 		else if (tileEntity->id == "BrushableBlock") {
                     // todo - anything interesting?
+		    // LootTable
+		    //     loot_tables/entities/warm_ocean_ruins_brushable_block.json
+		    //     loot_tables/entities/desert_pyramid_brushable_block.json
+		    //     loot_tables/entities/trail_ruins_brushable_block_common.json
+		    //     loot_tables/entities/trail_ruins_brushable_block_rare.json
+		    //     loot_tables/entities/warm_ocean_ruins_brushable_block.json
+		    // LootTableSeed
+		    // brush_count
+		    // brush_direction
+		    // type
+		    //     minecraft:suspicious_sand
+		    //     minecraft:suspicious_gravel
 		}
 		else if (tileEntity->id == "Campfire") {
                     // todo - anything interesting?
+		    // ItemTime1
+		    // ItemTime2
+		    // ItemTime3
+		    // ItemTime4
 		}
 		else if (tileEntity->id == "Lectern") {
                     // todo - anything interesting?
@@ -2233,12 +2268,21 @@ namespace mcpe_viz
 		}
 		else if (tileEntity->id == "SculkSensor") {
                     // todo - anything interesting?
+		    // VibrationListener : {'event' is  6 or 28}
 		}
 		else if (tileEntity->id == "SculkShrieker") {
                     // todo - anything interesting?
 		}
 		else if (tileEntity->id == "Smoker") {
                     // todo - anything interesting?
+		    // BurnDuration
+		    // BurnTime
+		    // CookTime
+		    // Items
+		    //     Slot 0 - Input
+		    //     Slot 1 - Fuel
+		    //     Slot 2 - Output
+		    // StoredXPInt
 		}
 		else if (tileEntity->id == "SporeBlossom") {
                     // todo - anything interesting?

--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -2220,6 +2220,84 @@ namespace mcpe_viz
                 }
                 else if (tileEntity->id == "Beehive") {
                     // todo - anything interesting?
+		    // Occupants
+		    //     ActorIdentifier - minecraft:bee<>
+		    //     SaveData
+		    //         Air
+		    //         Armor
+		    //         AttackTime
+		    //         Attributes
+		    //         BreedCooldown
+		    //         Chested
+		    //         Color
+		    //         Color2
+		    //         Dead
+		    //         DeathTime
+		    //         FallDistance
+		    //         HasExecuted
+		    //         HomeDimensionId
+		    //         HomePos
+		    //         HurtTime
+		    //         InLove
+		    //         Invulnerable
+		    //         IsAngry
+		    //         IsAutonomous
+		    //         IsBaby
+		    //         IsEating
+		    //         IsGliding
+		    //         IsGlobal
+		    //         IsIllagerCaptain
+		    //         IsOrphaned
+		    //         IsOutOfControl
+		    //         IsPregnant
+		    //         IsRoaring
+		    //         IsScared
+		    //         IsStunned
+		    //         IsSwimming
+		    //         IsTamed
+		    //         IsTrusting
+		    //         LeasherID
+		    //         LootDropped
+		    //         LoveCause
+		    //         Mainhand
+		    //         MarkVariant
+		    //         Motion
+		    //         NaturalSpawn
+		    //         Offhand
+		    //         OnGround
+		    //         OwnerNew
+		    //         Persistent
+		    //         PortalCooldown
+		    //         Pos
+		    //         Rotation
+		    //         Saddled
+		    //         Sheared
+		    //         ShowBottom
+		    //         Sitting
+		    //         SkinID
+		    //         Strength
+		    //         StrengthMax
+		    //         Surface
+		    //         Tags
+		    //         TargetID
+		    //         TimeStamp
+		    //         TradeExperience
+		    //         TradeTier
+		    //         UniqueID
+		    //         Variant
+		    //         boundX
+		    //         boundY
+		    //         boundZ
+		    //         canPickupItems
+		    //         definitions
+		    //         expDropEnabled
+		    //         hasBoundOrigin
+		    //         hasSetCanPickupItems
+		    //         identifier
+		    //         internalComponents
+		    //         properties
+		    //     TicksLeftToStay
+		    // ShouldSpawnBees
 		}
 		else if (tileEntity->id == "Bell") {
                     // todo - anything interesting?


### PR DESCRIPTION
This patch will remove the warnings about finding unknown tileEntities, and also adds comments for the unique attributes for each entity, making it easier for someone to tweak the geoJSON details for these in the future.