### PR TITLE
Update Minecraft wiki references

### DIFF
--- a/data/bedrock_viz.xml
+++ b/data/bedrock_viz.xml
@@ -1,9 +1,9 @@
 <xml>
   <!--
-      mostly from: http://minecraft.gamepedia.com/Data_values_%28Pocket_Edition%29
-      and:         https://minecraft.gamepedia.com/Pocket_Edition_data_values (more up to date than previous link)
-      and:         http://minecraft.gamepedia.com/Data_values#Block_IDs
-      and:         http://minecraft.gamepedia.com/Opacity
+      mostly from: https://minecraft.wiki/w/Data_values_%28Pocket_Edition%29 (deleted page)
+      and:         https://minecraft.wiki/w/Bedrock_Edition_data_values (active page)
+      and:         https://minecraft.wiki/w/Bedrock_Edition_data_values#Block_IDs
+      and:         https://minecraft.wiki/w/Opacity
       and:         https://gist.github.com/jocopa3/f8c9f9158ede0e9d057781188ba440f5
 
       blocklist: mcpe blocks
@@ -1582,7 +1582,7 @@
   </blocklist>
 
   <!--
-      mostly from: http://minecraft.gamepedia.com/Data_values_%28Pocket_Edition%29
+      mostly from: https://minecraft.wiki/w/Bedrock_Edition_data_values
 
       itemlist: mcpe items
       id - mcpe item id (hex)
@@ -2170,7 +2170,7 @@
   </itemlist>
 
   <!--
-      mostly from: http://minecraft.gamepedia.com/Data_values_%28Pocket_Edition%29
+      mostly from: https://minecraft.wiki/w/Bedrock_Edition_data_values
 
       entitylist: mcpe entities
       id - mcpe entity id (hex)
@@ -2325,7 +2325,7 @@
   </entitylist>
 
   <!--
-      mostly from: http://minecraft.gamepedia.com/Data_values#Biome_IDs
+      mostly from: https://minecraft.wiki/w/Bedrock_Edition_data_values#Block_IDs
 
       biomelist: mcpe biomes
       id - mcpe biome id (hex)
@@ -2422,7 +2422,7 @@
   </biomelist>
 
   <!--
-      note that values do NOT match: http://minecraft.gamepedia.com/Data_values#Enchantment_IDs
+      note that values do NOT match: https://minecraft.wiki/w/Bedrock_Edition_data_values#Enchantment_IDs
       these values were reverse engineered by me from MCPE directly
       todo - post these to mcpe wiki
   -->

--- a/include/world/dimension_data.h
+++ b/include/world/dimension_data.h
@@ -417,7 +417,7 @@ namespace mcpe_viz {
                     }
                     else if (imageMode == kImageModeSlimeChunksMCPC) {
                         /*
-              from: http://minecraft.gamepedia.com/Slime_chunk#Low_layers
+              from: https://minecraft.wiki/w/Slime_chunk
               Random rnd = new Random(seed +
               (long) (xPosition * xPosition * 0x4c1906) +
               (long) (xPosition * 0x5ac0db) +

--- a/src/main.cc
+++ b/src/main.cc
@@ -35,7 +35,7 @@
 
 
   * web - tool to extract schematics for a 3d cube of space -- produce a layer-by-layer depiction of the blocks in the cube
-  -- see: http://minecraft.gamepedia.com/Schematic_file_format  (NBT file format for schematics)
+  -- see: https://minecraft.wiki/w/Schematic_file_format  (NBT file format for schematics)
   -- https://irath96.github.io/webNBT/ = web nbt viewer/editor
 
   * /u/JustinUser -- reset world file outside given area (e.g. X blocks from spawn; given rectangles; etc)
@@ -156,7 +156,7 @@
   * join chests for geojson? (pairchest) - would require that we wait to toGeoJSON until we parse all chunks
   -- put ALL chests in a map<x,y,z>; go through list of chests and put PairChest in matching sets and mark all as unprocessed; go thru list and do all, if PairChest mark both as done
 
-  * see if there is interesting info re colors for overview map: http://minecraft.gamepedia.com/Map_item_format
+  * see if there is interesting info re colors for overview map: https://minecraft.wiki/w/Map_item_format
 
   * option to name output files w/ world name
 

--- a/src/nbt.cc
+++ b/src/nbt.cc
@@ -1781,7 +1781,7 @@ namespace mcpe_viz
             }
 
             // todo - diff entities have other fields:
-            // see: http://minecraft.gamepedia.com/Chunk_format#Mobs
+            // see: https://minecraft.wiki/w/Entity_format
 
             // chicken: IsChickenJockey
             entity->checkOtherProp(tc, "IsChickenJockey");
@@ -1834,7 +1834,7 @@ namespace mcpe_viz
 
                 if (vProfession >= 0) {
                     std::string vValue = "";
-                    // values from: http://minecraft.gamepedia.com/Villager#Data_values
+                    // values from: https://minecraft.wiki/w/Villager#Data_values
                     switch (vProfession) {
                     case 0:
                         vValue += "Farmer";
@@ -3208,7 +3208,7 @@ namespace mcpe_viz
 
         /*
           schematic file format
-          from: http://minecraft.gamepedia.com/Schematic_file_formathttp://minecraft.gamepedia.com/Schematic_file_format
+          from: https://minecraft.wiki/w/Schematic_file_format
 
           COMPOUND Schematic: Schematic data.
           SHORT Width: Size along the X axis.

--- a/src/world/chunk_data.cc
+++ b/src/world/chunk_data.cc
@@ -78,7 +78,7 @@ namespace mcpe_viz {
                         }
                         if (continueCheckSpawnFlag) {
 
-                            // note: rules adapted from: http://minecraft.gamepedia.com/Spawn
+                            // note: rules adapted from: https://minecraft.wiki/w/Spawn
 
                             // todobig - is this missing some spawnable blocks?
 
@@ -650,7 +650,7 @@ namespace mcpe_viz {
                         }
                         if (continueCheckSpawnFlag) {
 
-                            // note: rules adapted from: http://minecraft.gamepedia.com/Spawn
+                            // note: rules adapted from: https://minecraft.wiki/w/Spawn
 
                             // todobig - is this missing some spawnable blocks?
 

--- a/static/bedrock_viz.js
+++ b/static/bedrock_viz.js
@@ -2824,7 +2824,7 @@ function doTour(aboutFlag) {
                     '<li><a href="http://jquery.com/" target="_blank">jQuery</a></li>' +
                     '<li>Fork of <a href="https://github.com/Plethora777/mcpe_viz" target="_blank">MCPE Viz by Plethora777</a></li>' +
                     '</ul>' +
-                    'Block and Item images are borrowed from the <a href="http://minecraft.gamepedia.com/" target="_blank">Minecraft Wiki</a>.  The textures themselves are copyright Mojang.'
+                    'Block and Item images are borrowed from the <a href="https://minecraft.wiki" target="_blank">Minecraft Wiki</a>.  The textures themselves are copyright Mojang.'
             }
         ]});
     tour.init();


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all references accordingly.